### PR TITLE
Add github actions for docker

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,52 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*.*.*" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: docker/setup-buildx-action@v2
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v3
+      with:
+        tags: noseyparker
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Test the Docker image
+      run: docker run --rm noseyparker --help
+
+    - name: Login to github container registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push the image to `edge`
+      if: github.event_name == 'push' && github.ref_name == 'main'
+      run: |
+        docker tag noseyparker ghcr.io/${{ github.repository }}:edge
+        docker push ghcr.io/${{ github.repository }}:edge
+
+    - name: Push the image to `${{ github.ref_name }}`
+      if: github.ref_type == 'tag'
+      run: |
+        docker tag noseyparker ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+        docker push ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+
+    - name: Push the image to `latest`
+      if: github.ref_type == 'tag'
+      run: |
+        docker tag noseyparker ghcr.io/${{ github.repository }}:latest
+        docker push ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This automatically generates docker images from the repository and publishes them to the github container registry. The `main` branch is tagged with `:edge` and when you push git tags it tags those as `:v1.2.3` and `:latest`.

I ran the action in my fork and it now looks like this:

![image](https://user-images.githubusercontent.com/7763184/207708304-cf6d736a-3148-4d2c-bb44-393e6c858e8f.png)
