### PR TITLE
Cache Rust dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,76 @@
+ARG RUST_VER=1.65
+ARG VECTORSCAN_VER=5.4.8
+ARG VECTORSCAN_SHA=71fae7ee8d63e1513a6df762cdb5d5f02a9120a2422cf1f31d57747c2b8d36ab
+
 ################################################################################
-# Build Nosey Parker
+# Base stage
 ################################################################################
-FROM rust:1.65 as build
+FROM rust:$RUST_VER AS base
+
+ARG VECTORSCAN_VER
+ARG VECTORSCAN_SHA
+
+ENV HYPERSCAN_ROOT "/vectorscan/build"
+
+WORKDIR "/vectorscan"
+
+ADD https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/$VECTORSCAN_VER.tar.gz ./vectorscan.tar.gz
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update &&\
+    apt-get install -y \
     build-essential \
     cmake \
     git \
     libboost-dev \
     ninja-build \
     pkg-config \
-    ragel
-
-# Build vectorscan from source
-WORKDIR "/vectorscan"
-ADD https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.8.tar.gz vectorscan.tar.gz
-RUN echo '71fae7ee8d63e1513a6df762cdb5d5f02a9120a2422cf1f31d57747c2b8d36ab vectorscan.tar.gz' | sha256sum -c && \
-    tar --strip-components 1 -xzf vectorscan.tar.gz && \
-    cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DFAT_RUNTIME=OFF && \
+    ragel &&\
+    apt-get clean &&\
+    # Build vectorscan from source
+    echo "$VECTORSCAN_SHA vectorscan.tar.gz" | sha256sum -c &&\
+    tar --strip-components 1 -xzf vectorscan.tar.gz &&\
+    rm -rf vectorscan.tar.gz &&\
+    cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DFAT_RUNTIME=OFF &&\
     cmake --build build
 
-# Build Nosey Parker
+################################################################################
+# Build Rust dependencies, caching stage
+################################################################################
+FROM base AS dependencies
+
 WORKDIR "/noseyparker"
+
+COPY ["Cargo.toml", "Cargo.lock",  "./"]
+
+# Make directory structure
+RUN mkdir -p  ./src/bin/noseyparker &&\
+    mkdir -p ./benches &&\
+    # Create stub files for build
+    touch ./benches/microbench.rs ./src/lib.rs &&\
+    echo "fn main() {}" > ./src/bin/noseyparker/main.rs &&\
+    # Run the build
+    cargo build --bin noseyparker --release
+
+################################################################################
+# Build application
+################################################################################
+FROM dependencies AS build
+
+WORKDIR "/noseyparker"
+
 COPY . .
-# build against from-source vectorscan
-ENV HYPERSCAN_ROOT "/vectorscan/build"
-# XXX it would be nice if this could store crates.io index and dependency builds in the Docker cache
+
+# Update file timestamps
+RUN touch ./benches/microbench.rs ./src/lib.rs ./src/bin/noseyparker/main.rs
+
 RUN cargo build --release
 
 ################################################################################
 # Build a smaller image just for running the `noseyparker` binary
 ################################################################################
 FROM debian:11-slim
+
 COPY --from=build /noseyparker/target/release/noseyparker /usr/bin/noseyparker
 
 # Tip when running: use a volume mount: `-v "$PWD:/scan"` to make for handling of paths on the command line


### PR DESCRIPTION
Fixes #18

Added stage to Dockerfile for fetching and building Rust dependencies based on project's Cargo files. Creates stub files to facilitate build then in following stage copies full project and updates file timestamps to cause a compile on the actual project. Once the build is cached subsequent code changes will only impact the project's build stage. It's a little clunky, but unfortunately Cargo currently does not have a "fetch / build dependencies only" command.

Tested on my fork with CI builds. Initial Docker CI build takes ~15 minutes then subsequent build with 1 line code change took ~2 minutes.

Misc. comment: Could consider using a distroless image such as gcr.io/distroless/cc-debian11 in place of debian:11-slim for a smaller final run-time image.