### PR TITLE
Add SARIF output format for report #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Credentials in ODBC Connection String
   - PyPI Upload Token
 
+- The `report` command now offers rudimentary SARIF support ([#4](https://github.com/praetorian-inc/noseyparker/issues/4)).
+  Thanks you @Coruscant11!
+
 ### Changes
 - Several default rules have been revised to improve performance of the matching engine and to produce fewer false positives.
   In particular, several rules previously had avoided using a trailing `\b` anchor after secret content which could include a literal `-` character, due to a matching discrepancy between Hyperscan and Rust's `regex` library.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +660,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +705,37 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.7",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -1779,6 +1855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +2338,7 @@ dependencies = [
  "rusqlite",
  "secrecy",
  "serde",
+ "serde-sarif",
  "serde_json",
  "serde_yaml",
  "sha1",
@@ -2611,6 +2694,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "prettytable-rs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,6 +3043,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemafy_core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3d87f1df246a9b7e2bfd1f4ee5f88e48b11ef9cfc62e63f0dead255b1a6f5f"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn",
+ "uriparse",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3126,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-sarif"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47973bda4fb144010ea1c14b2677b6df84262627913e1c6a2682d8ed9e0dcc9"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "schemafy_lib",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "syn",
+ "thiserror",
 ]
 
 [[package]]
@@ -3163,6 +3303,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -3516,6 +3675,16 @@ name = "unsafe-libyaml"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
+
+[[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tracing-log = "0.1"
 tracing-subscriber = { version = "0.3", features = ["tracing-log", "ansi"] }
 url = "2.3"
 walkdir = "2.3"
+serde-sarif = "0.3.5"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0", features = ["color-auto"] }

--- a/src/bin/noseyparker/args.rs
+++ b/src/bin/noseyparker/args.rs
@@ -450,6 +450,12 @@ pub enum OutputFormat {
     ///
     /// This is a sequence of JSON objects, one per line.
     Jsonl,
+
+    /// SARIF format
+    ///
+    /// This is a JSON-based format used by Microsoft's Static Application Security Testing (SAST) tool.
+    /// See https://github.com/microsoft/sarif-tutorials
+    Sarif,
 }
 
 impl std::fmt::Display for OutputFormat {
@@ -458,6 +464,7 @@ impl std::fmt::Display for OutputFormat {
             OutputFormat::Human => "human",
             OutputFormat::Json => "json",
             OutputFormat::Jsonl => "jsonl",
+            OutputFormat::Sarif => "sarif",
         };
         write!(f, "{s}")
     }
@@ -470,6 +477,7 @@ pub trait Reportable {
     fn human_format<W: std::io::Write>(&self, writer: W) -> Result<()>;
     fn json_format<W: std::io::Write>(&self, writer: W) -> Result<()>;
     fn jsonl_format<W: std::io::Write>(&self, writer: W) -> Result<()>;
+    fn sarif_format<W: std::io::Write>(&self, writer: W) -> Result<()>;
 
     fn report(&self, output_args: &OutputArgs) -> Result<()> {
         let writer = output_args
@@ -480,6 +488,7 @@ pub trait Reportable {
             OutputFormat::Human => self.human_format(writer),
             OutputFormat::Json => self.json_format(writer),
             OutputFormat::Jsonl => self.jsonl_format(writer),
+            OutputFormat::Sarif => self.sarif_format(writer),
         };
         match result {
             Ok(()) => Ok(()),

--- a/src/bin/noseyparker/args.rs
+++ b/src/bin/noseyparker/args.rs
@@ -453,8 +453,8 @@ pub enum OutputFormat {
 
     /// SARIF format
     ///
-    /// This is a JSON-based format used by Microsoft's Static Application Security Testing (SAST) tool.
-    /// See https://github.com/microsoft/sarif-tutorials
+    /// This is the Static Analysis Results Interchange Format, a standardized JSON-based format used by many tools.
+    /// See the spec at <https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html>.
     Sarif,
 }
 

--- a/src/bin/noseyparker/cmd_github.rs
+++ b/src/bin/noseyparker/cmd_github.rs
@@ -46,4 +46,8 @@ impl Reportable for RepoReporter {
         }
         Ok(())
     }
+
+    fn sarif_format<W: std::io::Write>(&self, _writer: W) -> Result<()> {
+        bail!("SARIF output not supported for this command")
+    }
 }

--- a/src/bin/noseyparker/cmd_report.rs
+++ b/src/bin/noseyparker/cmd_report.rs
@@ -191,7 +191,6 @@ impl Reportable for DetailsReporter {
                                         .semantic_version(env!("CARGO_PKG_VERSION").to_string())
                                         .rules(
                                             rules.into_iter().map(|rule| {
-
                                                 let help = match sarif::MultiformatMessageStringBuilder::default()
                                                     .text(&rule.references.join("\n"))
                                                     .build() {
@@ -199,8 +198,7 @@ impl Reportable for DetailsReporter {
                                                         Err(_) => sarif::MultiformatMessageStringBuilder::default().text("No help available".to_string()).build().unwrap()
                                                     };
 
-
-                                                // If we can't parse the regex pattern, we just no dot put it in the sarif report
+                                                // If we can't parse the regex pattern, we just do not put it in the sarif report
                                                 match sarif::MultiformatMessageStringBuilder::default()
                                                     .text(rule.pattern)
                                                     .build() {

--- a/src/bin/noseyparker/cmd_report.rs
+++ b/src/bin/noseyparker/cmd_report.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
 use indenter::indented;
 use lazy_static::lazy_static;
+use noseyparker::rules::Rules;
 use serde::{Deserialize, Serialize, Serializer};
+use serde_sarif::sarif;
 use std::fmt::{Display, Formatter, Write};
 
 use noseyparker::bstring_escape::Escaped;
@@ -82,6 +84,153 @@ impl Reportable for DetailsReporter {
                 .map_err(|e| e.into())
                 .and_then(|()| writeln!(writer))?;
         }
+        Ok(())
+    }
+
+    fn sarif_format<W: std::io::Write>(&self, mut writer: W) -> Result<()> {
+        let datastore: &Datastore = &self.0;
+        let group_metadata = datastore
+            .get_match_group_metadata()
+            .context("Failed to get match group metadata from datastore")?;
+
+        // Will store every match for the runs.results array property
+        let mut results: Vec<sarif::Result> = vec![];
+
+        for metadata in group_metadata.into_iter() {
+            let matches = datastore
+                .get_match_group_matches(&metadata, None)
+                .with_context(|| format!("Failed to get matches for group {metadata:?}"))?;
+
+            // Will store every match location for the runs.results.location array property
+            let mut locations: Vec<sarif::Location> = vec![];
+
+            // Get the first blob id in the matches, will be written to the description in runs.results.message
+            let first_matched_blob = match matches.first() {
+                Some(m) => m.blob_id.to_string(),
+                None => String::new(),
+            };
+
+            for m in matches.into_iter() {
+                
+                // Build the location for the match
+                let location = sarif::LocationBuilder::default()
+                    .physical_location(
+                        sarif::PhysicalLocationBuilder::default()
+                            .artifact_location(
+                                sarif::ArtifactLocationBuilder::default()
+                                    .uri(
+                                        match &m.provenance {
+                                            Provenance::File { path} => String::from(path.to_str().with_context(|| format!("Failed to convert path to string: {:?}", &m.provenance))?),
+                                            Provenance::GitRepo { path } => String::from(path.to_str().with_context(|| format!("Failed to convert path to string: {:?}", &m.provenance))?),
+                                        }
+                                    )
+                                    .build()?,
+                            )
+                            .region(
+                                sarif::RegionBuilder::default()
+                                    .start_line(m.location.source_span.start.line as i64)
+                                    .start_column(m.location.source_span.start.column as i64)
+                                    .end_line(m.location.source_span.end.line as i64)
+                                    .end_column(m.location.source_span.end.column as i64)
+                                    .snippet(
+                                        sarif::ArtifactContentBuilder::default()
+                                            .text(m.snippet.matching.to_string())
+                                            .build()?,
+                                    )
+                                    .build()?,
+                            )
+                            .build()?,
+                        )
+                    .logical_locations(
+                        vec![
+                            sarif::LogicalLocationBuilder::default()
+                                .kind("blob")
+                                .name(m.blob_id.to_string())
+                                .build()?
+                        ]
+                    )
+                    .build()?;
+                    
+                locations.push(location);
+            }
+
+            // Build the result for the match
+            let result = sarif::ResultBuilder::default()
+                .rule_id(&metadata.rule_name)
+                .message(
+                    sarif::MessageBuilder::default()
+                        .text(format!("Rule {} has detected a secret with {} matches.\nFirst blob id matched : {}", &metadata.rule_name, &metadata.num_matches, first_matched_blob))
+                        .build()?,
+                )
+                .locations(locations)
+                .level(sarif::ResultLevel::Warning.to_string())
+                .build()?;
+            
+            results.push(result);
+        }
+
+        // Load the rules used during the scan for the runs.tool.driver.rules array property
+        let rules = Rules::from_default_rules().with_context(|| format!("Failed to load default rules"))?;
+        
+        let sr = sarif::SarifBuilder::default()
+            .version(sarif::Version::V2_1_0.to_string())
+            .schema("https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json")
+            .runs(
+                vec![
+                    sarif::RunBuilder::default()
+                        .tool(
+                            sarif::ToolBuilder::default()
+                                .driver(
+                                    sarif::ToolComponentBuilder::default()
+                                        .name(env!("CARGO_PKG_NAME").to_string())
+                                        .semantic_version(env!("CARGO_PKG_VERSION").to_string())
+                                        .rules(
+                                            rules.into_iter().map(|rule| {
+
+                                                let help = match sarif::MultiformatMessageStringBuilder::default()
+                                                    .text(&rule.references.join("\n"))
+                                                    .build() {
+                                                        Ok(help) => help,
+                                                        Err(_) => sarif::MultiformatMessageStringBuilder::default().text("No help available".to_string()).build().unwrap()
+                                                    };
+                                                    
+
+                                                // If we can't parse the regex pattern, we just no dot put it in the sarif report
+                                                match sarif::MultiformatMessageStringBuilder::default()
+                                                    .text(rule.pattern)
+                                                    .build() {
+                                                    Ok(description) => {
+                                                        return sarif::ReportingDescriptorBuilder::default()
+                                                            .id(&rule.name)
+                                                            .name(&rule.name)
+                                                            .short_description(description.clone())
+                                                            .full_description(description.clone())
+                                                            .help(help)
+                                                            .build()
+                                                    },
+                                                    Err(_) => {
+                                                        return sarif::ReportingDescriptorBuilder::default()
+                                                            .id(&rule.name)
+                                                            .name(&rule.name)
+                                                            .build()
+                                                    }
+                                                };
+                                            }).collect::<Result<Vec<_>, _>>()?
+                                        )
+                                        .build()?,
+                                    )
+                                    .build()?,
+                        )
+                        .results(results)
+                        .build()?,
+                ]
+            )
+            .build()?;
+
+        serde_json::to_writer(&mut writer, &sr)
+            .map_err(|e| e.into())
+            .and_then(|()| writeln!(writer))?;
+
         Ok(())
     }
 }

--- a/src/bin/noseyparker/cmd_report.rs
+++ b/src/bin/noseyparker/cmd_report.rs
@@ -170,7 +170,7 @@ impl Reportable for DetailsReporter {
         }
 
         // Load the rules used during the scan for the runs.tool.driver.rules array property
-        let rules = Rules::from_default_rules().with_context(|| format!("Failed to load default rules"))?;
+        let rules = Rules::from_default_rules().context("Failed to load default rules")?;
         
         let sr = sarif::SarifBuilder::default()
             .version(sarif::Version::V2_1_0.to_string())

--- a/src/bin/noseyparker/cmd_report.rs
+++ b/src/bin/noseyparker/cmd_report.rs
@@ -137,8 +137,8 @@ impl Reportable for DetailsReporter {
                                     .start_column(m.location.source_span.start.column as i64)
                                     .end_line(m.location.source_span.end.line as i64)
                                     .end_column(m.location.source_span.end.column as i64 + 1)
-                                    .byte_offset(m.location.offset_span.start as i64)
-                                    .byte_length(m.location.offset_span.len() as i64)
+                                    // .byte_offset(m.location.offset_span.start as i64)
+                                    // .byte_length(m.location.offset_span.len() as i64)
                                     .snippet(
                                         sarif::ArtifactContentBuilder::default()
                                             .text(m.snippet.matching.to_string())

--- a/src/bin/noseyparker/cmd_report.rs
+++ b/src/bin/noseyparker/cmd_report.rs
@@ -204,7 +204,7 @@ impl Reportable for DetailsReporter {
                                                             .id(&rule.name)
                                                             .name(&rule.name)
                                                             .short_description(description.clone())
-                                                            .full_description(description.clone())
+                                                            .full_description(description)
                                                             .help(help)
                                                             .build()
                                                     },

--- a/src/bin/noseyparker/cmd_report.rs
+++ b/src/bin/noseyparker/cmd_report.rs
@@ -116,22 +116,8 @@ impl Reportable for DetailsReporter {
                             .artifact_location(
                                 sarif::ArtifactLocationBuilder::default()
                                     .uri(match &m.provenance {
-                                        Provenance::File { path } => {
-                                            String::from(path.to_str().with_context(|| {
-                                                format!(
-                                                    "Failed to convert path to string: {:?}",
-                                                    &m.provenance
-                                                )
-                                            })?)
-                                        }
-                                        Provenance::GitRepo { path } => {
-                                            String::from(path.to_str().with_context(|| {
-                                                format!(
-                                                    "Failed to convert path to string: {:?}",
-                                                    &m.provenance
-                                                )
-                                            })?)
-                                        }
+                                        Provenance::File { path } => path.display().to_string(),
+                                        Provenance::GitRepo { path } => path.display().to_string(),
                                     })
                                     .build()?,
                             )

--- a/src/bin/noseyparker/cmd_report.rs
+++ b/src/bin/noseyparker/cmd_report.rs
@@ -92,7 +92,7 @@ impl Reportable for DetailsReporter {
             .context("Failed to get match group metadata from datastore")?;
 
         // Will store every match for the runs.results array property
-        let mut results: Vec<sarif::Result> = vec![];
+        let mut results: Vec<sarif::Result> = Vec::with_capacity(group_metadata.len());
 
         for metadata in group_metadata.into_iter() {
             let matches = datastore
@@ -100,7 +100,7 @@ impl Reportable for DetailsReporter {
                 .with_context(|| format!("Failed to get matches for group {metadata:?}"))?;
 
             // Will store every match location for the runs.results.location array property
-            let mut locations: Vec<sarif::Location> = vec![];
+            let mut locations: Vec<sarif::Location> = Vec::with_capacity(matches.len());
 
             // Get the first blob id in the matches, will be written to the description in runs.results.message
             let first_matched_blob = match matches.first() {

--- a/src/bin/noseyparker/cmd_report.rs
+++ b/src/bin/noseyparker/cmd_report.rs
@@ -126,7 +126,9 @@ impl Reportable for DetailsReporter {
                                     .start_line(m.location.source_span.start.line as i64)
                                     .start_column(m.location.source_span.start.column as i64)
                                     .end_line(m.location.source_span.end.line as i64)
-                                    .end_column(m.location.source_span.end.column as i64)
+                                    .end_column(m.location.source_span.end.column as i64 + 1)
+                                    .byte_offset(m.location.offset_span.start as i64)
+                                    .byte_length(m.location.offset_span.len() as i64)
                                     .snippet(
                                         sarif::ArtifactContentBuilder::default()
                                             .text(m.snippet.matching.to_string())

--- a/src/bin/noseyparker/cmd_scan.rs
+++ b/src/bin/noseyparker/cmd_scan.rs
@@ -211,11 +211,7 @@ pub fn run(global_args: &args::GlobalArgs, args: &args::ScanArgs) -> Result<()> 
                     }
                     Ok(p) => p,
                 };
-                if &path != &datastore_path {
-                    true
-                } else {
-                    false
-                }
+                path != datastore_path
             });
 
             Ok(ie)

--- a/src/bin/noseyparker/cmd_summarize.rs
+++ b/src/bin/noseyparker/cmd_summarize.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use indicatif::HumanCount;
 
 use noseyparker::datastore::{Datastore, MatchSummary};
@@ -30,6 +30,10 @@ impl Reportable for MatchSummaryReporter {
             writeln!(&mut writer)?;
         }
         Ok(())
+    }
+
+    fn sarif_format<W: std::io::Write>(&self, _writer: W) -> Result<()> {
+        bail!("SARIF output not supported for this command")
     }
 }
 

--- a/tests/snapshots/test_noseyparker_help__help_report-2.snap
+++ b/tests/snapshots/test_noseyparker_help__help_report-2.snap
@@ -30,6 +30,7 @@ Output Options:
           - human: A text-based format designed for humans
           - json:  Pretty-printed JSON format
           - jsonl: JSON Lines format
+          - sarif: SARIF format
 
 Global Options:
   -v, --verbose...

--- a/tests/snapshots/test_noseyparker_help__help_report_short-2.snap
+++ b/tests/snapshots/test_noseyparker_help__help_report_short-2.snap
@@ -13,7 +13,7 @@ Options:
 Output Options:
   -o, --output <PATH>    Write output to the specified path
   -f, --format <FORMAT>  Write output in the specified format [default: human] [possible values:
-                         human, json, jsonl]
+                         human, json, jsonl, sarif]
 
 Global Options:
   -v, --verbose...       Enable verbose output

--- a/tests/snapshots/test_noseyparker_help__help_summarize-2.snap
+++ b/tests/snapshots/test_noseyparker_help__help_summarize-2.snap
@@ -30,6 +30,7 @@ Output Options:
           - human: A text-based format designed for humans
           - json:  Pretty-printed JSON format
           - jsonl: JSON Lines format
+          - sarif: SARIF format
 
 Global Options:
   -v, --verbose...

--- a/tests/snapshots/test_noseyparker_help__help_summarize_short-2.snap
+++ b/tests/snapshots/test_noseyparker_help__help_summarize_short-2.snap
@@ -13,7 +13,7 @@ Options:
 Output Options:
   -o, --output <PATH>    Write output to the specified path
   -f, --format <FORMAT>  Write output in the specified format [default: human] [possible values:
-                         human, json, jsonl]
+                         human, json, jsonl, sarif]
 
 Global Options:
   -v, --verbose...       Enable verbose output

--- a/tests/test_noseyparker_scan.rs
+++ b/tests/test_noseyparker_scan.rs
@@ -201,6 +201,7 @@ mod test_scan_git_url {
 // TODO: add test for scanning with `--github-user`
 // TODO: add test for scanning with `--github-org`
 // TODO: add test for caching behavior of rescanning `--git-url`
+// TODO: add tests for SARIF output format
 
 #[test]
 fn scan_secrets1() {


### PR DESCRIPTION
Fixes #4 

Hello :wave: 

## Resources

https://github.com/microsoft/sarif-tutorials/

For this PR I used the crate `serde-sarif`.
Documentation available here : https://docs.rs/serde-sarif/latest/serde_sarif/
And I took inspiration from [this code](https://github.com/flatt-security/shisho/blob/322f1111382b0d6556e11d3fe99bb3195c7ee2d7/src/cli/reporter/sarif.rs).


Here is my PR. Feel free to tell me where I may have done something wrong! It is the first time that I try to contribute to another project. :smile: 
I tested on several report and everything should work. 
The `sarif_format` function in `cmd_report.rs` is quite long. Is it an issue? Should I dispatch in multiple functions or not? 

## Improvements 
- **Add commits details :**  If in the future commits details will be added to blob match, I will add them. Linked to #16 
- **Specify only used regex rules :** One of the features of `sarif` is to specify used rules. In my case I simply added **all default rules** of noseyparker in the file. We could add only used rules in order to save space. I know that rules names are available but I didn't find a way to efficiently found their associated regex, in the report code scope.


## Tools
Here is a tool allowing to try to read SARIF files : https://microsoft.github.io/sarif-web-component/
And there is also the VSCode extension `Sarif Viewer` : https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer

## Examples 
I tried in several repositories, and everything seems ok. 
Here is an example for CPython : 

![image](https://user-images.githubusercontent.com/1645347/221327384-d32110ec-e48b-4772-bca6-ae55ee5955a6.png)

## SARIF Template example for NoseyParker

```json
{
  "version": "2.1.0",
  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
  "runs": [
    {
      "tool": {
        "driver": {
          "name": "noseyparker",
          "semanticVersion": "0.11.0",
          "rules": [
            {
              "id": "RULE_NAME",
              "name": "RULE_NAME",
              "shortDescription": {
                "text": "REGEX_RULE"
              }
            }
            ...
          ]
        }
      },
      "results": [
        {
          "message": {
            "text": "Rule {} has detected a secret with {} matches.\nFirst blob id matched : {}"
          },
          "ruleId": "RULE_NAME",
          "level": "warning",
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "PATH_TO_FILE"
                },
                "region": {
                  "startLine": "STARTLINE",
                  "startColumn": "STARTCOLUMN",
                  "endLine": "ENDLINE",
                  "endColumn": "ENDCOLUMN",
                  "snippet": {
                    "text": "THE_SECRET"
                  }
                }
              }
            }
            ...
          ]
        }
        ...
      ]
    }
  ]
}
```

