### PR TITLE
Added Dependency Track rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New rules have been added:
 
+  - Dependency-Track API Key (Thank you @tpat13!)
   - React App Username
   - React App Password
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nosey Parker is a command-line tool that finds secrets and sensitive information
 
 **Key features:**
 - It supports scanning files, directories, and the entire history of Git repositories
-- It uses regular expression matching with a set of 110 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
+- It uses regular expression matching with a set of 111 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
 - It groups matches together that share the same secret, further emphasizing signal over noise
 - It is fast: it can scan at hundreds of megabytes per second on a single core, and is able to scan 100GB of Linux kernel source history in less than 2 minutes on an older MacBook Pro
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,5 +2,5 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-110 rules and 2 rulesets: no issues detected
+111 rules and 2 rulesets: no issues detected
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -77,6 +77,10 @@ expression: stdout
       "name": "DigitalOcean Refresh Token"
     },
     {
+      "id": "np.dtrack.1",
+      "name": "Dependency-Track API Key"
+    },
+    {
       "id": "np.dynatrace.1",
       "name": "Dynatrace Token"
     },
@@ -454,7 +458,7 @@ expression: stdout
     {
       "id": "np.default",
       "name": "Nosey Parker default rules",
-      "num_rules": 95
+      "num_rules": 96
     }
   ]
 }

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -23,6 +23,7 @@ expression: stdout
  np.digitalocean.1   DigitalOcean Application Access Token 
  np.digitalocean.2   DigitalOcean Personal Access Token 
  np.digitalocean.3   DigitalOcean Refresh Token 
+ np.dtrack.1         Dependency-Track API Key 
  np.dynatrace.1      Dynatrace Token 
  np.facebook.1       Facebook Secret Key 
  np.facebook.2       Facebook Access Token 
@@ -119,5 +120,5 @@ expression: stdout
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
  np.assets    Nosey Parker asset detection rules      15 
- np.default   Nosey Parker default rules              95 
+ np.default   Nosey Parker default rules              96 
 

--- a/crates/noseyparker/data/default/builtin/rules/dependency_track.yml
+++ b/crates/noseyparker/data/default/builtin/rules/dependency_track.yml
@@ -1,0 +1,20 @@
+rules:
+
+- name: Dependency-Track API Key
+  id: np.dtrack.1
+  pattern: (^odt_[A-Za-z0-9]{32,255}$)
+
+  examples:
+  - 'odt_KTJlDq2AGGGlqG4riKdT7p980AW8RlU5'
+  - 'odt_ABCDDq2AGxGlrF4ribBT7p98AOM9TlU8'
+  - 'odt_FHxhQGh77JAHHIYpZ818UQ0aYjXIdMIxxgeR'
+
+  negative_examples:
+    - 'KTJlDq2AGGGlqG8riKdT7p980AW8RlU5'
+    - 'ABCDDq2AGxGlqG 4ribBT7p98AOM9TlU8'
+    - 'FHxhQGh77_JAHHIYpZ818UQ0aYjXIdMIxxgeR'
+
+  references:
+  - https://docs.dependencytrack.org/integrations/rest-api/
+  - https://docs.dependencytrack.org/getting-started/configuration/
+

--- a/crates/noseyparker/data/default/builtin/rules/dependency_track.yml
+++ b/crates/noseyparker/data/default/builtin/rules/dependency_track.yml
@@ -1,8 +1,11 @@
 rules:
 
+# This detects occurrences of a Dependency-Track API key that uses the default
+# `odt_` key prefix. This prefix was set as the default in the Dependency-Track
+# v4.9.0 release on October 16, 2023.
 - name: Dependency-Track API Key
   id: np.dtrack.1
-  pattern: (^odt_[A-Za-z0-9]{32,255}$)
+  pattern: '\b(odt_[A-Za-z0-9]{32,255})\b'
 
   examples:
   - 'odt_KTJlDq2AGGGlqG4riKdT7p980AW8RlU5'
@@ -18,3 +21,8 @@ rules:
   - https://docs.dependencytrack.org/integrations/rest-api/
   - https://docs.dependencytrack.org/getting-started/configuration/
 
+  # Code that implements stuff related to the API key
+  - https://github.com/stevespringett/Alpine/blob/92fdb7de7e5623b8c986de08997480036af5f472/alpine-model/src/main/java/alpine/model/ApiKey.java
+
+  # Issue about adding support for the `odt_` default key prefix
+  - https://github.com/DependencyTrack/dependency-track/pull/3047

--- a/crates/noseyparker/data/default/builtin/rulesets/np.default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/np.default.yml
@@ -30,6 +30,7 @@ rulesets:
   - np.bcrypt.1       # bcrypt Hash
   - np.codeclimate.1  # CodeClimate
   - np.cratesio.1     # crates.io API Key
+  - np.dtrack.1       # Dependency-Track API Key
   - np.digitalocean.1 # DigitalOcean Application Access Token
   - np.digitalocean.2 # DigitalOcean Personal Access Token
   - np.digitalocean.3 # DigitalOcean Refresh Token


### PR DESCRIPTION
Dependency-Track identifies vulnerabilities using a project's Bill of Materials. DTrack has included `odt_ ` as the prefix for tokens in their [default configuration](https://docs.dependencytrack.org/getting-started/configuration/). DTrack is based on Alpine which the API Key (not including the prefix) can be [between 32 and 255 characters long](https://github.com/stevespringett/Alpine/blob/master/alpine-model/src/main/java/alpine/model/ApiKey.java).