### PR TITLE
Add WireGuard PrivateKey/PresharedKey rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project aspires to use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Additions
+
+- New rule has been added:
+
+  - WireGuard PrivateKey/PresharedKey
+
+
 ## [v0.16.0](https://github.com/praetorian-inc/noseyparker/releases/v0.16.0) (2023-12-06)
 
 ### Additions

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nosey Parker is a command-line tool that finds secrets and sensitive information
 
 **Key features:**
 - It supports scanning files, directories, and the entire history of Git repositories
-- It uses regular expression matching with a set of 114 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
+- It uses regular expression matching with a set of 115 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
 - It groups matches together that share the same secret, further emphasizing signal over noise
 - It is fast: it can scan at hundreds of megabytes per second on a single core, and is able to scan 100GB of Linux kernel source history in less than 2 minutes on an older MacBook Pro
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,5 +2,5 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-114 rules and 3 rulesets: no issues detected
+115 rules and 3 rulesets: no issues detected
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,5 +2,5 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-115 rules and 3 rulesets: no issues detected
+116 rules and 3 rulesets: no issues detected
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -462,14 +462,18 @@ expression: stdout
     },
     {
       "id": "np.wireguard.1",
-      "name": "WireGuard PrivateKey/PresharedKey"
+      "name": "WireGuard Private Key"
+    },
+    {
+      "id": "np.wireguard.2",
+      "name": "WireGuard Preshared Key"
     }
   ],
   "rulesets": [
     {
       "id": "default",
       "name": "Nosey Parker default rules",
-      "num_rules": 95
+      "num_rules": 96
     },
     {
       "id": "np.assets",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -459,13 +459,17 @@ expression: stdout
     {
       "id": "np.twitter.2",
       "name": "Twitter Secret Key"
+    },
+    {
+      "id": "np.wireguard.1",
+      "name": "WireGuard PrivateKey/PresharedKey"
     }
   ],
   "rulesets": [
     {
       "id": "default",
       "name": "Nosey Parker default rules",
-      "num_rules": 94
+      "num_rules": 95
     },
     {
       "id": "np.assets",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -119,11 +119,12 @@ expression: stdout
  np.twilio.1         Twilio API Key 
  np.twitter.1        Twitter Client ID 
  np.twitter.2        Twitter Secret Key 
- np.wireguard.1      WireGuard PrivateKey/PresharedKey 
+ np.wireguard.1      WireGuard Private Key 
+ np.wireguard.2      WireGuard Preshared Key 
 
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
- default      Nosey Parker default rules              95 
+ default      Nosey Parker default rules              96 
  np.assets    Nosey Parker asset detection rules      15 
  np.hashes    Nosey Parker password hash rules         5 
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -119,10 +119,11 @@ expression: stdout
  np.twilio.1         Twilio API Key 
  np.twitter.1        Twitter Client ID 
  np.twitter.2        Twitter Secret Key 
+ np.wireguard.1      WireGuard PrivateKey/PresharedKey 
 
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
- default      Nosey Parker default rules              94 
+ default      Nosey Parker default rules              95 
  np.assets    Nosey Parker asset detection rules      15 
  np.hashes    Nosey Parker password hash rules         5 
 

--- a/crates/noseyparker/data/default/builtin/rules/wireguard.yml
+++ b/crates/noseyparker/data/default/builtin/rules/wireguard.yml
@@ -1,0 +1,28 @@
+# These rules are specifically designed to identify WireGuard .conf files,
+# with a focus on detecting private and preshared keys contained within them.
+
+rules:
+
+- name: WireGuard PrivateKey/PresharedKey
+  id: np.wireguard.1
+
+  pattern: |
+    (?x)
+    PrivateKey|PresharedKey\s*=\s*
+    ([A-Za-z0-9+/]{43}={1})
+
+  examples:
+  - |
+      [Interface]
+      Address = 10.200.200.3/32
+      PrivateKey = AsaFot43bfs1fEWjvtty+rGcjh3rP1H6sug1l3u19ix=
+      DNS = 8.8.8.8
+      [Peer]
+      PublicKey = [Server's public key]
+      PresharedKey = uRsfsZ2Ts1rach4Zv3hhwcx6wa5fuIo2u3w7sa+7j81=
+      AllowedIPs = 0.0.0.0/0, ::/0
+      Endpoint = [Server Addr:Server Port]
+
+  references:
+  - https://www.wireguard.com/quickstart/
+  - https://gist.github.com/lanceliao/5d2977f417f34dda0e3d63ac7e217fd6

--- a/crates/noseyparker/data/default/builtin/rules/wireguard.yml
+++ b/crates/noseyparker/data/default/builtin/rules/wireguard.yml
@@ -3,13 +3,10 @@
 
 rules:
 
-- name: WireGuard PrivateKey/PresharedKey
+- name: WireGuard Private Key
   id: np.wireguard.1
 
-  pattern: |
-    (?x)
-    PrivateKey|PresharedKey\s*=\s*
-    ([A-Za-z0-9+/]{43}={1})
+  pattern: PrivateKey\s*=\s*([A-Za-z0-9+/]{43})
 
   examples:
   - |
@@ -17,6 +14,19 @@ rules:
       Address = 10.200.200.3/32
       PrivateKey = AsaFot43bfs1fEWjvtty+rGcjh3rP1H6sug1l3u19ix=
       DNS = 8.8.8.8
+
+  references:
+  - https://www.wireguard.com/quickstart/
+  - https://manpages.debian.org/testing/wireguard-tools/wg.8.en.html
+  - https://gist.github.com/lanceliao/5d2977f417f34dda0e3d63ac7e217fd6
+
+- name: WireGuard Preshared Key
+  id: np.wireguard.2
+
+  pattern: PresharedKey\s*=\s*([A-Za-z0-9+/]{43}=)
+
+  examples:
+  - |
       [Peer]
       PublicKey = [Server's public key]
       PresharedKey = uRsfsZ2Ts1rach4Zv3hhwcx6wa5fuIo2u3w7sa+7j81=
@@ -25,4 +35,5 @@ rules:
 
   references:
   - https://www.wireguard.com/quickstart/
+  - https://manpages.debian.org/testing/wireguard-tools/wg.8.en.html
   - https://gist.github.com/lanceliao/5d2977f417f34dda0e3d63ac7e217fd6

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -109,4 +109,5 @@ rulesets:
   - np.telegram.1     # Telegram Bot Token
   - np.twilio.1       # Twilio API Key
   - np.twitter.2      # Twitter Secret Key
-  - np.wireguard.1    # WireGuard PrivateKey/PresharedKey
+  - np.wireguard.1    # WireGuard Private Key
+  - np.wireguard.2    # WireGuard Preshared Key

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -109,3 +109,4 @@ rulesets:
   - np.telegram.1     # Telegram Bot Token
   - np.twilio.1       # Twilio API Key
   - np.twitter.2      # Twitter Secret Key
+  - np.wireguard.1    # WireGuard PrivateKey/PresharedKey


### PR DESCRIPTION
This is a rule I regularly use to look for WireGuard .conf files (specifically private and preshared WG keys). Maybe it makes sense to add it to the defaults. I generated the 2 keys in the example myself just for this purpose.