### PR TITLE
Fix WireGuard Private Key pattern

### DIFF
--- a/crates/noseyparker/data/default/builtin/rules/wireguard.yml
+++ b/crates/noseyparker/data/default/builtin/rules/wireguard.yml
@@ -6,7 +6,7 @@ rules:
 - name: WireGuard Private Key
   id: np.wireguard.1
 
-  pattern: PrivateKey\s*=\s*([A-Za-z0-9+/]{43})
+  pattern: PrivateKey\s*=\s*([A-Za-z0-9+/]{43}=)
 
   examples:
   - |


### PR DESCRIPTION
This is another follow-up to #104 where WireGuard rules were added. But it seems I accidentally removed an `=` from the regex pattern while splitting the rules. Now it is fixed and the pattern is more strict.