### PR TITLE
Fix Docker Hub Personal Access Token rule

### DIFF
--- a/crates/noseyparker/data/default/builtin/rules/dockerhub.yml
+++ b/crates/noseyparker/data/default/builtin/rules/dockerhub.yml
@@ -7,11 +7,12 @@ rules:
     (?x)
     \b
     (dckr_pat_[a-zA-Z0-9_-]{27})
-    \b
+    (?: $ | [^a-zA-Z0-9_-] )
 
   examples:
   - docker login -u gemesa -p dckr_pat_hc8VxYclixyTr2rDFsa2rqzkP3Y
   - docker login -u gemesa -p dckr_pat_tkzBYxjNNC3R_Yg6jd_O-G8FbrJ
+  - docker login -u gemesa -p dckr_pat_1q8yKET1VDJTpfCwseUDzT8vFh-
 
   references:
   - https://docs.docker.com/security/for-developers/access-tokens/


### PR DESCRIPTION
`-` could be the last character here also, so I updated the pattern similarly to https://github.com/praetorian-inc/noseyparker/pull/108#discussion_r1431708161.