### PR TITLE
Add Doppler rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New rules have been added:
 
   - Docker Hub Personal Access Token ([#108](https://github.com/praetorian-inc/noseyparker/pull/108) - thank you @gemesa!)
+  - Doppler CLI Token
+  - Doppler Personal Token
+  - Doppler Service Token
+  - Doppler Service Account Token
+  - Doppler SCIM Token
+  - Doppler Audit Token
   - Dropbox Access Token ([#106](https://github.com/praetorian-inc/noseyparker/pull/106) - thank you @gemesa!)
   - TrueNAS API Key (WebSocket)
   - TrueNAS API Key (REST API)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nosey Parker is a command-line tool that finds secrets and sensitive information
 
 **Key features:**
 - It supports scanning files, directories, and the entire history of Git repositories
-- It uses regular expression matching with a set of 120 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
+- It uses regular expression matching with a set of 126 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
 - It groups matches together that share the same secret, further emphasizing signal over noise
 - It is fast: it can scan at hundreds of megabytes per second on a single core, and is able to scan 100GB of Linux kernel source history in less than 2 minutes on an older MacBook Pro
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,5 +2,5 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-120 rules and 3 rulesets: no issues detected
+126 rules and 3 rulesets: no issues detected
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -77,6 +77,30 @@ expression: stdout
       "name": "Docker Hub Personal Access Token"
     },
     {
+      "id": "np.doppler.1",
+      "name": "Doppler CLI Token"
+    },
+    {
+      "id": "np.doppler.2",
+      "name": "Doppler Personal Token"
+    },
+    {
+      "id": "np.doppler.3",
+      "name": "Doppler Service Token"
+    },
+    {
+      "id": "np.doppler.4",
+      "name": "Doppler Service Account Token"
+    },
+    {
+      "id": "np.doppler.5",
+      "name": "Doppler SCIM Token"
+    },
+    {
+      "id": "np.doppler.6",
+      "name": "Doppler Audit Token"
+    },
+    {
       "id": "np.dropbox.1",
       "name": "Dropbox Access Token"
     },
@@ -489,7 +513,7 @@ expression: stdout
     {
       "id": "default",
       "name": "Nosey Parker default rules",
-      "num_rules": 100
+      "num_rules": 106
     },
     {
       "id": "np.assets",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -23,6 +23,12 @@ expression: stdout
  np.digitalocean.2   DigitalOcean Personal Access Token 
  np.digitalocean.3   DigitalOcean Refresh Token 
  np.dockerhub.1      Docker Hub Personal Access Token 
+ np.doppler.1        Doppler CLI Token 
+ np.doppler.2        Doppler Personal Token 
+ np.doppler.3        Doppler Service Token 
+ np.doppler.4        Doppler Service Account Token 
+ np.doppler.5        Doppler SCIM Token 
+ np.doppler.6        Doppler Audit Token 
  np.dropbox.1        Dropbox Access Token 
  np.dtrack.1         Dependency-Track API Key 
  np.dynatrace.1      Dynatrace Token 
@@ -128,7 +134,7 @@ expression: stdout
 
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
- default      Nosey Parker default rules             100 
+ default      Nosey Parker default rules             106 
  np.assets    Nosey Parker asset detection rules      15 
  np.hashes    Nosey Parker password hash rules         5 
 

--- a/crates/noseyparker/data/default/builtin/rules/doppler.yml
+++ b/crates/noseyparker/data/default/builtin/rules/doppler.yml
@@ -1,0 +1,97 @@
+rules:
+
+- name: Doppler CLI Token
+  id: np.doppler.1
+
+  pattern: |
+    (?x)
+    \b
+    (dp\.ct\.[a-zA-Z0-9]{40,44})
+    \b
+
+  examples:
+  - dp.ct.bAqhcVzrhy5cRHkOlNTc0Ve6w5NUDCpcutm8vGE9myi
+
+  references:
+  - https://docs.doppler.com/reference/api
+  - https://docs.doppler.com/reference/auth-token-formats
+
+- name: Doppler Personal Token
+  id: np.doppler.2
+
+  pattern: |
+    (?x)
+    \b
+    (dp\.pt\.[a-zA-Z0-9]{40,44})
+    \b
+
+  examples:
+  - dp.pt.bAqhcVzrhy5cRHkOlNTc0Ve6w5NUDCpcutm8vGE9myi
+
+  references:
+  - https://docs.doppler.com/reference/api
+  - https://docs.doppler.com/reference/auth-token-formats
+
+- name: Doppler Service Token
+  id: np.doppler.3
+
+  pattern: |
+    (?x)
+    \b
+    (dp\.st\.(?:[a-z0-9\-_]{2,35}\.)?[a-zA-Z0-9]{40,44})
+    \b
+
+  examples:
+  - dp.st.dev.bAqhcVzrhy5cRHkOlNTc0Ve6w5NUDCpcutm8vGE9myi
+
+  references:
+  - https://docs.doppler.com/reference/api
+  - https://docs.doppler.com/reference/auth-token-formats
+
+- name: Doppler Service Account Token
+  id: np.doppler.4
+
+  pattern: |
+    (?x)
+    \b
+    (dp\.sa\.[a-zA-Z0-9]{40,44})
+    \b
+
+  examples:
+  - dp.sa.bAqhcVzrhy5cRHkOlNTc0Ve6w5NUDCpcutm8vGE9myi
+
+  references:
+  - https://docs.doppler.com/reference/api
+  - https://docs.doppler.com/reference/auth-token-formats
+
+- name: Doppler SCIM Token
+  id: np.doppler.5
+
+  pattern: |
+    (?x)
+    \b
+    (dp\.scim\.[a-zA-Z0-9]{40,44})
+    \b
+
+  examples:
+  - dp.scim.bAqhcVzrhy5cRHkOlNTc0Ve6w5NUDCpcutm8vGE9myi
+
+  references:
+  - https://docs.doppler.com/reference/api
+  - https://docs.doppler.com/reference/auth-token-formats
+
+- name: Doppler Audit Token
+  id: np.doppler.6
+
+  pattern: |
+    (?x)
+    \b
+    (dp\.audit\.[a-zA-Z0-9]{40,44})
+    \b
+
+  examples:
+  - dp.audit.bAqhcVzrhy5cRHkOlNTc0Ve6w5NUDCpcutm8vGE9myi
+
+  references:
+  - https://docs.doppler.com/reference/api
+  - https://docs.doppler.com/reference/auth-token-formats

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -30,6 +30,12 @@ rulesets:
   - np.digitalocean.2 # DigitalOcean Personal Access Token
   - np.digitalocean.3 # DigitalOcean Refresh Token
   - np.dockerhub.1    # Docker Hub Personal Access Token
+  - np.doppler.1      # Doppler CLI Token
+  - np.doppler.2      # Doppler Personal Token
+  - np.doppler.3      # Doppler Service Token
+  - np.doppler.4      # Doppler Service Account Token
+  - np.doppler.5      # Doppler SCIM Token
+  - np.doppler.6      # Doppler Audit Token
   - np.dropbox.1      # Dropbox Access Token
   - np.dynatrace.1    # Dynatrace Token
   - np.facebook.1     # Facebook Secret Key


### PR DESCRIPTION
I was surprised this is not already included in the default rules, as it is a direct copy-paste from [doppler.com](https://docs.doppler.com/reference/auth-token-formats), lol