### PR TITLE
Add particle.io rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Doppler SCIM Token ([#111](https://github.com/praetorian-inc/noseyparker/pull/111))
   - Doppler Audit Token ([#111](https://github.com/praetorian-inc/noseyparker/pull/111))
   - Dropbox Access Token ([#106](https://github.com/praetorian-inc/noseyparker/pull/106))
+  - particle.io Access Token (URL first) ([#112](https://github.com/praetorian-inc/noseyparker/pull/113))
+  - particle.io Access Token (URL last) ([#112](https://github.com/praetorian-inc/noseyparker/pull/113))
   - ThingsBoard Access Token ([#112](https://github.com/praetorian-inc/noseyparker/pull/112))
   - ThingsBoard Provision Device Key ([#112](https://github.com/praetorian-inc/noseyparker/pull/112))
   - ThingsBoard Provision Device Secret ([#112](https://github.com/praetorian-inc/noseyparker/pull/112))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nosey Parker is a command-line tool that finds secrets and sensitive information
 
 **Key features:**
 - It supports scanning files, directories, and the entire history of Git repositories
-- It uses regular expression matching with a set of 129 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
+- It uses regular expression matching with a set of 131 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
 - It groups matches together that share the same secret, further emphasizing signal over noise
 - It is fast: it can scan at hundreds of megabytes per second on a single core, and is able to scan 100GB of Linux kernel source history in less than 2 minutes on an older MacBook Pro
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,5 +2,5 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-129 rules and 3 rulesets: no issues detected
+131 rules and 3 rulesets: no issues detected
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -341,6 +341,14 @@ expression: stdout
       "name": "OpenAI API Key"
     },
     {
+      "id": "np.particleio.1",
+      "name": "particle.io Access Token (URL first)"
+    },
+    {
+      "id": "np.particleio.2",
+      "name": "particle.io Access Token (URL last)"
+    },
+    {
       "id": "np.pem.1",
       "name": "PEM-Encoded Private Key"
     },
@@ -525,7 +533,7 @@ expression: stdout
     {
       "id": "default",
       "name": "Nosey Parker default rules",
-      "num_rules": 109
+      "num_rules": 111
     },
     {
       "id": "np.assets",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -89,6 +89,8 @@ expression: stdout
  np.odbc.1           Credentials in ODBC Connection String 
  np.okta.1           Okta API Token 
  np.openai.1         OpenAI API Key 
+ np.particleio.1     particle.io Access Token (URL first) 
+ np.particleio.2     particle.io Access Token (URL last) 
  np.pem.1            PEM-Encoded Private Key 
  np.postman.1        Postman API Key 
  np.psexec.1         Credentials in PsExec 
@@ -137,7 +139,7 @@ expression: stdout
 
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
- default      Nosey Parker default rules             109 
+ default      Nosey Parker default rules             111 
  np.assets    Nosey Parker asset detection rules      15 
  np.hashes    Nosey Parker password hash rules         5 
 

--- a/crates/noseyparker/data/default/builtin/rules/particle.io.yml
+++ b/crates/noseyparker/data/default/builtin/rules/particle.io.yml
@@ -1,0 +1,51 @@
+rules:
+
+- name: particle.io Access Token (URL first)
+  id: np.particleio.1
+
+  pattern: |
+    (?x)
+    https://api\.particle\.io/v1/[a-zA-Z0-9_\-\s/"\\?]*
+    (?:access_token=|Authorization:\s*Bearer\s*)
+    \b
+    ([a-zA-Z0-9]{40})
+    \b
+
+  examples:
+  - |
+      curl https://api.particle.io/v1/devices \
+      -H "Authorization: Bearer 38bb7b318cc6898c80317decb34525844bc9db55"
+  - |
+      curl https://api.particle.io/v1/devices \
+      -d access_token=38bb7b318cc6898c80317decb34525844bc9db55
+  - 'curl https://api.particle.io/v1/devices -H "Authorization: Bearer 38bb7b318cc6898c80317decb34525844bc9db55"'
+  - 'curl https://api.particle.io/v1/devices -d access_token=38bb7b318cc6898c80317decb34525844bc9db55'
+  - 'curl "https://api.particle.io/v1/devices/events?access_token=38bb7b318cc6898c80317decb34525844bc9db55"'
+  - 'curl "https://api.particle.io/v1/access_tokens/current?access_token=38bb7b318cc6898c80317decb34525844bc9db55"'
+
+  references:
+  - https://docs.particle.io/reference/cloud-apis/api/
+
+- name: particle.io Access Token (URL last)
+  id: np.particleio.2
+
+  pattern: |
+    (?x)
+    (?:access_token=|Authorization:\s*Bearer\s*)
+    \b
+    ([a-zA-Z0-9]{40})
+    \b
+    [\s"\\]*https://api\.particle\.io/v1
+
+  examples:
+  - |
+      curl -H "Authorization: Bearer 38bb7b318cc6898c80317decb34525844bc9db55" \
+      https://api.particle.io/v1/devices
+  - |
+      curl -d access_token=38bb7b318cc6898c80317decb34525844bc9db55 \
+      https://api.particle.io/v1/devices
+  - 'curl -H "Authorization: Bearer 38bb7b318cc6898c80317decb34525844bc9db55" https://api.particle.io/v1/devices'
+  - 'curl -d access_token=38bb7b318cc6898c80317decb34525844bc9db55 https://api.particle.io/v1/devices'
+
+  references:
+  - https://docs.particle.io/reference/cloud-apis/api/

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -89,6 +89,8 @@ rulesets:
   - np.odbc.1         # Credentials in ODBC Connection String
   - np.okta.1         # Okta API Token
   - np.openai.1       # OpenAI API Key
+  - np.particleio.1   # particle.io Access Token (URL first)
+  - np.particleio.2   # particle.io Access Token (URL last)
   - np.pem.1          # PEM-Encoded Private Key
   - np.postman.1      # Postman API Key
   - np.psexec.1       # Credentials in PsExec


### PR DESCRIPTION
Added some rules I successfully used to detect particle.io access tokens in the wild. The rules do not contain any patterns to match device IDs because once we have the access tokens, we can retrieve the device list with `curl "https://api.particle.io/v1/devices?access_token=38bb7b318cc6898c80317decb34525844bc9db55"`.

I created two patterns that could be merged into one but this way they are more readable.