### PR TITLE
Add Adafruit IO Key rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New rules have been added (thank you @gemesa!):
 
+  - Adafruit IO Key ([#114](https://github.com/praetorian-inc/noseyparker/pull/114))
   - Docker Hub Personal Access Token ([#108](https://github.com/praetorian-inc/noseyparker/pull/108))
   - Doppler CLI Token ([#111](https://github.com/praetorian-inc/noseyparker/pull/111))
   - Doppler Personal Token ([#111](https://github.com/praetorian-inc/noseyparker/pull/111))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nosey Parker is a command-line tool that finds secrets and sensitive information
 
 **Key features:**
 - It supports scanning files, directories, and the entire history of Git repositories
-- It uses regular expression matching with a set of 131 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
+- It uses regular expression matching with a set of 132 patterns chosen for high signal-to-noise based on experience and feedback from offensive security engagements
 - It groups matches together that share the same secret, further emphasizing signal over noise
 - It is fast: it can scan at hundreds of megabytes per second on a single core, and is able to scan 100GB of Linux kernel source history in less than 2 minutes on an older MacBook Pro
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,5 +2,5 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-131 rules and 3 rulesets: no issues detected
+132 rules and 3 rulesets: no issues detected
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -5,6 +5,10 @@ expression: stdout
 {
   "rules": [
     {
+      "id": "np.adafruit.1",
+      "name": "Adafruit IO Key"
+    },
+    {
       "id": "np.adobe.1",
       "name": "Adobe OAuth Client Secret"
     },
@@ -533,7 +537,7 @@ expression: stdout
     {
       "id": "default",
       "name": "Nosey Parker default rules",
-      "num_rules": 111
+      "num_rules": 112
     },
     {
       "id": "np.assets",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -5,6 +5,7 @@ expression: stdout
 
  Rule ID             Rule Name 
 ─────────────────────────────────────────────────────────────────────────────
+ np.adafruit.1       Adafruit IO Key 
  np.adobe.1          Adobe OAuth Client Secret 
  np.age.1            Age Recipient (X25519 public key) 
  np.age.2            Age Identity (X22519 secret key) 
@@ -139,7 +140,7 @@ expression: stdout
 
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
- default      Nosey Parker default rules             111 
+ default      Nosey Parker default rules             112 
  np.assets    Nosey Parker asset detection rules      15 
  np.hashes    Nosey Parker password hash rules         5 
 

--- a/crates/noseyparker/data/default/builtin/rules/adafruitio.yml
+++ b/crates/noseyparker/data/default/builtin/rules/adafruitio.yml
@@ -1,0 +1,18 @@
+rules:
+
+- name: Adafruit IO Key
+  id: np.adafruit.1
+
+  pattern: |
+    (?x)
+    \b
+    (aio\_[a-zA-Z0-9]{28})
+    \b
+
+  examples:
+  - '#define IO_KEY       "aio_NrZCb67VvzSaM7fr3nMXrfZ1uMPH"'
+  - 'export IO_KEY="aio_NrZCb67VvzSaM7fr3nMXrfZ1uMPH"'
+  - 'ADAFRUIT_IO_KEY = "aio_NrZCb67VvzSaM7fr3nMXrfZ1uMPH"'
+
+  references:
+  - https://io.adafruit.com/api/docs

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -15,6 +15,7 @@ rulesets:
 
 
   include_rule_ids:
+  - np.adafruit.1     # Adafruit IO Key
   - np.adobe.1        # Adobe OAuth Client Secret
   - np.age.2          # Age Identity (X22519 secret key)
   - np.artifactory.1  # Artifactory API Key


### PR DESCRIPTION
Added Adafruit IO key rule. Based on the [API docs](https://io.adafruit.com/api/docs) it is not immediately obvious that the keys have an `aio_` prefix but they do. I verified this:

![aio](https://github.com/praetorian-inc/noseyparker/assets/59890178/d8907652-b42b-4787-b17e-8af4e8a64d65)
