### PR TITLE
Allow to ignore validation of TLS certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Additions
 
+- Allow ignoring validation of TLS certificates with new `--ignore-certs` flag ([#125](https://github.com/praetorian-inc/noseyparker/pull/125))
 - New rules have been added (thank you @gemesa!):
 
   - Adafruit IO Key ([#114](https://github.com/praetorian-inc/noseyparker/pull/114))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Additions
 
-- Allow ignoring validation of TLS certificates with new `--ignore-certs` flag ([#125](https://github.com/praetorian-inc/noseyparker/pull/125))
+- Allow ignoring validation of TLS certificates with new `--ignore-certs` flag ([#125](https://github.com/praetorian-inc/noseyparker/pull/125); thank you @seqre!)
 - New rules have been added (thank you @gemesa!):
 
   - Adafruit IO Key ([#114](https://github.com/praetorian-inc/noseyparker/pull/114))

--- a/crates/noseyparker-cli/src/args.rs
+++ b/crates/noseyparker-cli/src/args.rs
@@ -331,6 +331,10 @@ pub struct GitHubReposListArgs {
 
     #[command(flatten)]
     pub output_args: OutputArgs<GitHubOutputFormat>,
+
+    /// Ignore validation of TLS certificates
+    #[arg(long)]
+    pub ignore_certs: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -500,6 +504,10 @@ pub struct ScanArgs {
         help_heading="Data Collection Options",
     )]
     pub copy_blobs: CopyBlobsMode,
+
+    /// Ignore validation of TLS certificates
+    #[arg(long)]
+    pub ignore_certs: bool,
 
 }
 

--- a/crates/noseyparker-cli/src/cmd_github.rs
+++ b/crates/noseyparker-cli/src/cmd_github.rs
@@ -22,6 +22,7 @@ fn list_repos(_global_args: &GlobalArgs, args: &GitHubReposListArgs, api_url: Ur
             organization: args.repo_specifiers.organization.clone(),
         },
         api_url,
+        args.ignore_certs,
         None,
     )
     .context("Failed to enumerate GitHub repositories")?;

--- a/crates/noseyparker-cli/src/cmd_scan.rs
+++ b/crates/noseyparker-cli/src/cmd_scan.rs
@@ -94,7 +94,7 @@ pub fn run(global_args: &args::GlobalArgs, args: &args::ScanArgs) -> Result<()> 
             let mut num_found: u64 = 0;
             let api_url = args.input_specifier_args.github_api_url.clone();
             for repo_string in
-                github::enumerate_repo_urls(&repo_specifiers, api_url, Some(&mut progress))
+                github::enumerate_repo_urls(&repo_specifiers, api_url, args.ignore_certs, Some(&mut progress))
                     .context("Failed to enumerate GitHub repositories")?
             {
                 match GitUrl::from_str(&repo_string) {

--- a/crates/noseyparker-cli/src/cmd_scan.rs
+++ b/crates/noseyparker-cli/src/cmd_scan.rs
@@ -137,7 +137,7 @@ pub fn run(global_args: &args::GlobalArgs, args: &args::ScanArgs) -> Result<()> 
             args::GitCloneMode::Mirror => CloneMode::Mirror,
             args::GitCloneMode::Bare => CloneMode::Bare,
         };
-        let git = Git::new();
+        let git = Git::new(args.ignore_certs);
 
         let mut progress =
             Progress::new_bar(repo_urls.len() as u64, "Fetching Git repos", progress_enabled);

--- a/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_scan-2.snap
+++ b/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_scan-2.snap
@@ -177,6 +177,9 @@ Metadata Collection Options:
             blob is first seen
           - minimal:    Only the Git repository in which a blob is seen
 
+      --ignore-certs
+          Ignore validation of TLS certificates
+
 Data Collection Options:
       --snippet-length <BYTES>
           Include up to the specified number of bytes before and after each match

--- a/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_scan_short-2.snap
+++ b/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_scan_short-2.snap
@@ -38,6 +38,7 @@ Metadata Collection Options:
                                     matching] [possible values: all, matching, none]
       --git-blob-provenance <MODE>  Specify which Git commit provenance metadata will be collected
                                     [default: first-seen] [possible values: first-seen, minimal]
+      --ignore-certs                Ignore validation of TLS certificates
 
 Data Collection Options:
       --snippet-length <BYTES>  Include up to the specified number of bytes before and after each

--- a/crates/noseyparker/src/git_binary.rs
+++ b/crates/noseyparker/src/git_binary.rs
@@ -22,10 +22,11 @@ pub enum GitError {
 
 pub struct Git {
     credentials: Vec<String>,
+    ignore_certs: bool,
 }
 
 impl Git {
-    pub fn new() -> Self {
+    pub fn new(ignore_certs: bool) -> Self {
         let credentials: Vec<String> = // if std::env::var("NP_GITHUB_TOKEN").is_ok() {
             [
                 "-c",
@@ -38,7 +39,7 @@ impl Git {
         // };
         ;
 
-        Self { credentials }
+        Self { credentials, ignore_certs }
     }
 
     fn git(&self) -> Command {
@@ -46,6 +47,9 @@ impl Git {
         cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
         cmd.env("GIT_CONFIG_NOSYSTEM", "1");
         cmd.env("GIT_CONFIG_SYSTEM", "/dev/null");
+        if self.ignore_certs {
+            cmd.env("GIT_SSL_NO_VERIFY", "1");
+        }
         cmd.args(&self.credentials);
         cmd.stdin(Stdio::null());
         cmd
@@ -105,7 +109,7 @@ impl Git {
 impl Default for Git {
     /// Equivalent to `Git::new()`
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 

--- a/crates/noseyparker/src/github.rs
+++ b/crates/noseyparker/src/github.rs
@@ -24,6 +24,7 @@ use progress::Progress;
 pub fn enumerate_repo_urls(
     repo_specifiers: &RepoSpecifiers,
     github_url: Url,
+    ignore_certs: bool,
     progress: Option<&mut Progress>,
 ) -> anyhow::Result<Vec<String>> {
     use anyhow::{bail, Context};
@@ -34,6 +35,7 @@ pub fn enumerate_repo_urls(
         .context("Failed to set base URL")?
         .personal_access_token_from_env()
         .context("Failed to get GitHub access token from environment")?
+        .ignore_certs(ignore_certs)
         .build()
         .context("Failed to initialize GitHub client")?;
 

--- a/crates/noseyparker/src/github/client_builder.rs
+++ b/crates/noseyparker/src/github/client_builder.rs
@@ -10,6 +10,7 @@ use super::{Auth, Client, Error, Result};
 pub struct ClientBuilder {
     base_url: reqwest::Url,
     auth: Auth,
+    ignore_certs: bool,
 }
 
 impl ClientBuilder {
@@ -21,6 +22,7 @@ impl ClientBuilder {
         ClientBuilder {
             base_url: Url::parse("https://api.github.com").expect("default base URL should parse"),
             auth: Auth::Unauthenticated,
+            ignore_certs: false,
         }
     }
 
@@ -33,6 +35,12 @@ impl ClientBuilder {
     /// Use the given authentication mechanism.
     pub fn auth(mut self, auth: Auth) -> Self {
         self.auth = auth;
+        self
+    }
+
+    /// Ignore validation of TLS certs.
+    pub fn ignore_certs(mut self, ignore_certs: bool) -> Self {
+        self.ignore_certs = ignore_certs;
         self
     }
 
@@ -62,6 +70,7 @@ impl ClientBuilder {
     pub fn build(self) -> Result<Client> {
         let inner = reqwest::ClientBuilder::new()
             .user_agent(Self::USER_AGENT)
+            .danger_accept_invalid_certs(self.ignore_certs)
             .build()?;
         Ok(Client {
             base_url: self.base_url,


### PR DESCRIPTION
This PR closes #116. If there's a need for tests or anything else, I can add them.

There are two approaches I see to CLI arguments:

1. (implemented right now) For each command that interacts with certificates, add an argument to its defined arguments and pass it to the functions. It's more local, closer to actual use, yet adds more places where it needs to be maintained.
2. Consider this to be a global argument. The plus of this approach is that there is only one place for the user to set it, and it could be easily used if additional clients were to be added in the future (e.g. GitLab or something else). The disadvantage is that it would require more modification to the code as `GlobalArgs` is not always passed that deep. Also, it wouldn't apply to all subcommands, so it wouldn't be truly "global".


