### PR TITLE
Add JSON Schema support via schemars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "base64",
  "bstr",
  "proptest",
+ "schemars",
  "serde",
  "serde_json",
 ]
@@ -746,6 +747,12 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "either"
@@ -2124,6 +2131,7 @@ dependencies = [
  "pretty_assertions",
  "progress",
  "roaring",
+ "schemars",
  "serde",
  "smallvec",
  "tracing",
@@ -2497,6 +2505,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
+ "schemars",
  "secrecy",
  "serde",
  "serde_json",
@@ -2540,6 +2549,7 @@ dependencies = [
  "rayon",
  "regex",
  "rlimit",
+ "schemars",
  "serde",
  "serde-sarif",
  "serde_json",
@@ -3259,6 +3269,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "smallvec",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,6 +3378,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.49",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/bstring-serde/Cargo.toml
+++ b/crates/bstring-serde/Cargo.toml
@@ -14,6 +14,7 @@ publish.workspace = true
 [dependencies]
 base64 = { version = "0.21" }
 bstr = { version = "1.0", features = ["serde"] }
+schemars = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/input-enumerator/Cargo.toml
+++ b/crates/input-enumerator/Cargo.toml
@@ -16,12 +16,11 @@ anyhow = { version = "1.0" }
 bstr = { version = "1.0", features = ["serde"] }
 bstring-serde = { path = "../bstring-serde" }
 fixedbitset = "0.4"
-
 gix = { version = "0.58", features = ["max-performance", "serde"] }
-
 ignore = "0.4"
 petgraph = "0.6"
 roaring = "0.10"
+schemars = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 smallvec = { version = "1", features = ["const_generics", "const_new", "union"] }
 tracing = "0.1"

--- a/crates/input-enumerator/src/git_commit_metadata.rs
+++ b/crates/input-enumerator/src/git_commit_metadata.rs
@@ -1,6 +1,8 @@
 use bstr::BString;
 use gix::date::Time;
 use gix::ObjectId;
+use schemars::JsonSchema;
+use serde::{Serialize, Deserialize};
 
 use bstring_serde::BStringLossyUtf8;
 
@@ -12,12 +14,40 @@ fn serialize_object_id<S: serde::Serializer>(object_id: &ObjectId, serializer: S
 
 */
 
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote="Time")]
+struct TextTime(
+    #[serde(
+        getter = "text_time::getter",
+        serialize_with = "text_time::serialize",
+        deserialize_with = "text_time::deserialize",
+    )]
+    Time
+);
+
+impl From<TextTime> for Time {
+    fn from(v: TextTime) -> Self {
+        v.0
+    }
+}
+
+impl From<Time> for TextTime {
+    fn from(v: Time) -> Self {
+        Self(v)
+    }
+}
+
 mod text_time {
     use super::*;
 
-    pub fn serialize<S: serde::Serializer>(time: &Time, serializer: S) -> Result<S::Ok, S::Error> {
+    pub fn getter(v: &Time) -> &Time {
+        v
+    }
+
+    pub fn serialize<S: serde::Serializer>(v: &Time, serializer: S) -> Result<S::Ok, S::Error> {
         // XXX any way to do this without allocating?
-        serializer.serialize_str(&time.to_bstring().to_string())
+        serializer.serialize_str(&v.to_bstring().to_string())
     }
 
     pub fn deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Time, D::Error> {
@@ -37,8 +67,46 @@ mod text_time {
     }
 }
 
+impl JsonSchema for TextTime {
+    fn schema_name() -> String {
+        "Time".into()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+}
+
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote="ObjectId")]
+struct HexObjectId(
+    #[serde(
+        getter = "hex_object_id::getter",
+        serialize_with = "hex_object_id::serialize",
+        deserialize_with = "hex_object_id::deserialize",
+    )]
+    ObjectId
+);
+
+impl From<ObjectId> for HexObjectId {
+    fn from(v: ObjectId) -> Self {
+        HexObjectId(v)
+    }
+}
+
+impl From<HexObjectId> for ObjectId {
+    fn from(v: HexObjectId) -> Self {
+        v.0
+    }
+}
+
 mod hex_object_id {
     use super::*;
+
+    pub fn getter(v: &ObjectId) -> &ObjectId {
+        v
+    }
 
     pub fn serialize<S: serde::Serializer>(v: &ObjectId, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.collect_str(&v.to_hex())
@@ -61,9 +129,25 @@ mod hex_object_id {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
+impl JsonSchema for HexObjectId {
+    fn schema_name() -> String {
+        "ObjectId".into()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let s = String::json_schema(gen);
+        let mut o = s.into_object();
+        o.string().pattern = Some("[0-9a-f]{40}".into());
+        let md = o.metadata();
+        md.description = Some("A hex-encoded object ID as computed by Git".into());
+        schemars::schema::Schema::Object(o)
+    }
+}
+
+/// Metadata about a Git commit.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub struct CommitMetadata {
-    #[serde(with="hex_object_id")]
+    #[serde(with="HexObjectId")]
     pub commit_id: ObjectId,
 
     #[serde(with = "BStringLossyUtf8")]
@@ -72,7 +156,7 @@ pub struct CommitMetadata {
     #[serde(with = "BStringLossyUtf8")]
     pub committer_email: BString,
 
-    #[serde(with = "text_time")]
+    #[serde(with = "TextTime")]
     pub committer_timestamp: Time,
 
     #[serde(with = "BStringLossyUtf8")]
@@ -81,7 +165,7 @@ pub struct CommitMetadata {
     #[serde(with = "BStringLossyUtf8")]
     pub author_email: BString,
 
-    #[serde(with = "text_time")]
+    #[serde(with = "TextTime")]
     pub author_timestamp: Time,
 
     #[serde(with = "BStringLossyUtf8")]

--- a/crates/noseyparker-cli/Cargo.toml
+++ b/crates/noseyparker-cli/Cargo.toml
@@ -64,6 +64,7 @@ progress = { path = "../progress" }
 rayon = "1.5"
 regex = "1.7"
 rlimit = "0.10.0"
+schemars = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde-sarif = "0.4"

--- a/crates/noseyparker-cli/src/args.rs
+++ b/crates/noseyparker-cli/src/args.rs
@@ -179,17 +179,21 @@ pub enum Command {
     #[command(display_order = 4, name = "github")]
     GitHub(GitHubArgs),
 
-    #[command(display_order = 30)]
     /// Manage datastores
+    #[command(display_order = 30)]
     Datastore(DatastoreArgs),
 
-    #[command(display_order = 30)]
     /// Manage rules
+    #[command(display_order = 30)]
     Rules(RulesArgs),
 
-    #[command(display_order = 40)]
     /// Generate shell completions
+    #[command(display_order = 40, hide=true)]
     ShellCompletions(ShellCompletionsArgs),
+
+    /// Generate the JSON schema for the output of the `report` command
+    #[command(display_order = 50, hide=true)]
+    JsonSchema(JsonSchemaArgs),
 }
 
 // -----------------------------------------------------------------------------
@@ -793,6 +797,13 @@ pub enum ShellFormat {
 pub struct ShellCompletionsArgs {
     #[arg(long, short, value_name = "SHELL")]
     pub shell: ShellFormat,
+}
+
+// -----------------------------------------------------------------------------
+// `json-schema` command
+// -----------------------------------------------------------------------------
+#[derive(Args, Debug)]
+pub struct JsonSchemaArgs {
 }
 
 // -----------------------------------------------------------------------------

--- a/crates/noseyparker-cli/src/cmd_json_schema.rs
+++ b/crates/noseyparker-cli/src/cmd_json_schema.rs
@@ -1,0 +1,10 @@
+use crate::args::{GlobalArgs, JsonSchemaArgs};
+use crate::cmd_report::Finding;
+
+use anyhow::Result;
+
+pub fn run(_global_args: &GlobalArgs, _args: &JsonSchemaArgs) -> Result<()> {
+    let schema = schemars::schema_for!(Vec<Finding>);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+    return Ok(());
+}

--- a/crates/noseyparker-cli/src/cmd_report.rs
+++ b/crates/noseyparker-cli/src/cmd_report.rs
@@ -23,10 +23,6 @@ mod styles;
 use styles::{StyledObject, Styles};
 
 pub fn run(global_args: &GlobalArgs, args: &ReportArgs) -> Result<()> {
-    // let schema = schemars::schema_for!(Vec<Finding>);
-    // println!("{}", serde_json::to_string_pretty(&schema).unwrap());
-    // return Ok(());
-
     let datastore = Datastore::open(&args.datastore, global_args.advanced.sqlite_cache_size)
         .with_context(|| format!("Failed to open datastore at {}", args.datastore.display()))?;
     let output = args
@@ -169,7 +165,7 @@ impl DetailsReporter {
 
 /// A group of matches that all have the same rule and capture group content
 #[derive(Serialize, JsonSchema)]
-struct Finding {
+pub(crate) struct Finding {
     #[serde(flatten)]
     metadata: FindingMetadata,
     matches: Vec<ReportMatch>,

--- a/crates/noseyparker-cli/src/main.rs
+++ b/crates/noseyparker-cli/src/main.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 mod args;
 mod cmd_datastore;
 mod cmd_github;
+mod cmd_json_schema;
 mod cmd_report;
 mod cmd_rules;
 mod cmd_scan;
@@ -104,6 +105,7 @@ fn try_main(args: &CommandLineArgs) -> Result<()> {
         args::Command::Summarize(args) => cmd_summarize::run(global_args, args),
         args::Command::Report(args) => cmd_report::run(global_args, args),
         args::Command::ShellCompletions(args) => cmd_shell_completions::run(global_args, args),
+        args::Command::JsonSchema(args) => cmd_json_schema::run(global_args, args),
     }
 }
 

--- a/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help-2.snap
+++ b/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help-2.snap
@@ -8,14 +8,13 @@ and Git history.
 Usage: noseyparker [OPTIONS] <COMMAND>
 
 Commands:
-  scan               Scan content for secrets
-  summarize          Summarize scan findings
-  report             Report detailed scan findings
-  github             Interact with GitHub
-  datastore          Manage datastores
-  rules              Manage rules
-  shell-completions  Generate shell completions
-  help               Print this message or the help of the given subcommand(s)
+  scan       Scan content for secrets
+  summarize  Summarize scan findings
+  report     Report detailed scan findings
+  github     Interact with GitHub
+  datastore  Manage datastores
+  rules      Manage rules
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help

--- a/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_short-2.snap
+++ b/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_short-2.snap
@@ -8,14 +8,13 @@ and Git history.
 Usage: noseyparker [OPTIONS] <COMMAND>
 
 Commands:
-  scan               Scan content for secrets
-  summarize          Summarize scan findings
-  report             Report detailed scan findings
-  github             Interact with GitHub
-  datastore          Manage datastores
-  rules              Manage rules
-  shell-completions  Generate shell completions
-  help               Print this message or the help of the given subcommand(s)
+  scan       Scan content for secrets
+  summarize  Summarize scan findings
+  report     Report detailed scan findings
+  github     Interact with GitHub
+  datastore  Manage datastores
+  rules      Manage rules
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help (see more with '--help')

--- a/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__no_args-3.snap
+++ b/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__no_args-3.snap
@@ -8,14 +8,13 @@ and Git history.
 Usage: noseyparker [OPTIONS] <COMMAND>
 
 Commands:
-  scan               Scan content for secrets
-  summarize          Summarize scan findings
-  report             Report detailed scan findings
-  github             Interact with GitHub
-  datastore          Manage datastores
-  rules              Manage rules
-  shell-completions  Generate shell completions
-  help               Print this message or the help of the given subcommand(s)
+  scan       Scan content for secrets
+  summarize  Summarize scan findings
+  report     Report detailed scan findings
+  github     Interact with GitHub
+  datastore  Manage datastores
+  rules      Manage rules
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help (see more with '--help')

--- a/crates/noseyparker/Cargo.toml
+++ b/crates/noseyparker/Cargo.toml
@@ -27,9 +27,7 @@ bstring-serde = { path = "../bstring-serde" }
 chrono = { version = "0.4", default_features = false, features = ["std"] }
 console = "0.15"
 fixedbitset = "0.4"
-
 gix = { version = "0.58", features = ["max-performance", "serde"] }
-
 hex = "0.4"
 include_dir = { version = "0.7", features = ["glob"] }
 input-enumerator = { path = "../input-enumerator" }
@@ -42,6 +40,7 @@ progress = { path = "../progress" }
 regex = "1.7"
 reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
 rusqlite = { version = "0.30", features = ["bundled", "backup", "serde_json"] }
+schemars = { version = "0.8", features = ["smallvec"] }
 secrecy = "0.8.0"
 smallvec = { version = "1", features = ["const_generics", "const_new", "union"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/noseyparker/src/blob_id.rs
+++ b/crates/noseyparker/src/blob_id.rs
@@ -14,6 +14,21 @@ impl std::fmt::Debug for BlobId {
     }
 }
 
+impl schemars::JsonSchema for BlobId {
+    fn schema_name() -> String {
+        "BlobId".into()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let s = String::json_schema(gen);
+        let mut o = s.into_object();
+        o.string().pattern = Some("[0-9a-f]{40}".into());
+        let md = o.metadata();
+        md.description = Some("A hex-encoded blob ID as computed by Git".into());
+        schemars::schema::Schema::Object(o)
+    }
+}
+
 impl BlobId {
     /// Create a new BlobId computed from the given input.
     #[inline]

--- a/crates/noseyparker/src/blob_metadata.rs
+++ b/crates/noseyparker/src/blob_metadata.rs
@@ -1,7 +1,7 @@
 use crate::blob_id::BlobId;
 
 /// Metadata about a blob
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
 pub struct BlobMetadata {
     /// The blob ID this metadata applies to
     pub id: BlobId,

--- a/crates/noseyparker/src/datastore.rs
+++ b/crates/noseyparker/src/datastore.rs
@@ -3,6 +3,7 @@ use bstr::BString;
 use indoc::indoc;
 use noseyparker_rules::Rule;
 use rusqlite::Connection;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::path::{Path, PathBuf};
@@ -881,7 +882,7 @@ impl std::fmt::Display for FindingSummary {
 // -------------------------------------------------------------------------------------------------
 
 /// Metadata for a group of matches that have identical rule name and match content.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct FindingMetadata {
     /// The content-based finding identifier for this group of matches
     pub finding_id: String,
@@ -930,7 +931,7 @@ pub struct FindingDataEntry {
 // -------------------------------------------------------------------------------------------------
 
 /// A status assigned to a match group
-#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 // FIXME(overhaul): use an integer representation for serialization and db
 pub enum Status {
@@ -942,7 +943,7 @@ pub enum Status {
 // Statuses
 // -------------------------------------------------------------------------------------------------
 /// A collection of statuses
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 // FIXME(overhaul): use a bitflag representation here?
 pub struct Statuses(pub SmallVec<[Status; 16]>);

--- a/crates/noseyparker/src/location.rs
+++ b/crates/noseyparker/src/location.rs
@@ -1,10 +1,11 @@
 use core::ops::Range;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // -------------------------------------------------------------------------------------------------
 // OffsetPoint
 // -------------------------------------------------------------------------------------------------
-/// A single-point location within a bytestring
+/// A point defined by a byte offset.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Copy, Clone)]
 pub struct OffsetPoint(pub usize);
 
@@ -19,8 +20,10 @@ impl OffsetPoint {
 // -------------------------------------------------------------------------------------------------
 // OffsetSpan
 // -------------------------------------------------------------------------------------------------
-/// A non-empty span within a bytestring
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// A non-empty span, defined by two byte offsets.
+/// This is a half-open interval.
+/// A valid span will have an end value greater than the start value.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub struct OffsetSpan {
     pub start: usize,
     pub end: usize,
@@ -68,7 +71,9 @@ impl OffsetSpan {
 // -------------------------------------------------------------------------------------------------
 // SourcePoint
 // -------------------------------------------------------------------------------------------------
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Copy, Clone)]
+/// A point defined by line and column offsets.
+/// Lines are indexed from 1; columns are indexed from 0.
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SourcePoint {
     pub line: usize,
     pub column: usize,
@@ -83,8 +88,9 @@ impl std::fmt::Display for SourcePoint {
 // -------------------------------------------------------------------------------------------------
 // SourceSpan
 // -------------------------------------------------------------------------------------------------
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
-// FIXME: is this a half-open or closed interval?  Clarify this.
+/// A span defined by two source points.
+/// This is a clsoed interval.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SourceSpan {
     pub start: SourcePoint,
     pub end: SourcePoint,
@@ -152,7 +158,8 @@ impl LocationMapping {
 // -------------------------------------------------------------------------------------------------
 // Location
 // -------------------------------------------------------------------------------------------------
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// A span, including both the byte- and source-based representation.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct Location {
     pub offset_span: OffsetSpan,
     pub source_span: SourceSpan,

--- a/crates/noseyparker/src/match_type.rs
+++ b/crates/noseyparker/src/match_type.rs
@@ -1,6 +1,8 @@
 use bstr::BString;
 use bstring_serde::BStringBase64;
 use noseyparker_digest::Sha1;
+use schemars::JsonSchema;
+use serde::{Serialize, Deserialize};
 use smallvec::SmallVec;
 use std::io::Write;
 use tracing::debug;
@@ -13,7 +15,7 @@ use crate::snippet::Snippet;
 // -------------------------------------------------------------------------------------------------
 // Group
 // -------------------------------------------------------------------------------------------------
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Group(#[serde(with = "BStringBase64")] pub BString);
 
 impl Group {
@@ -25,7 +27,7 @@ impl Group {
 // -------------------------------------------------------------------------------------------------
 // Groups
 // -------------------------------------------------------------------------------------------------
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Groups(pub SmallVec<[Group; 1]>);
 
 // -------------------------------------------------------------------------------------------------
@@ -64,7 +66,7 @@ mod sql {
 // -------------------------------------------------------------------------------------------------
 // Match
 // -------------------------------------------------------------------------------------------------
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct Match {
     /// The blob this match comes from
     pub blob_id: BlobId,

--- a/crates/noseyparker/src/provenance.rs
+++ b/crates/noseyparker/src/provenance.rs
@@ -1,6 +1,7 @@
 use bstr::BString;
 use bstring_serde::BStringLossyUtf8;
 use input_enumerator::git_commit_metadata::CommitMetadata;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::{PathBuf, Path};
 
@@ -9,7 +10,7 @@ use std::path::{PathBuf, Path};
 // Provenance
 // -------------------------------------------------------------------------------------------------
 /// `Provenance` indicates where a particular blob or match was found when scanning.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 #[allow(clippy::large_enum_variant)]
 pub enum Provenance {
@@ -97,7 +98,7 @@ impl std::fmt::Display for Provenance {
 // FileProvenance
 // -------------------------------------------------------------------------------------------------
 /// Indicates that a blob was seen at a particular file path
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct FileProvenance {
     pub path: PathBuf,
 }
@@ -106,7 +107,7 @@ pub struct FileProvenance {
 // GitRepoProvenance
 // -------------------------------------------------------------------------------------------------
 /// Indicates that a blob was seen in a Git repo, optionally with particular commit provenance info
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct GitRepoProvenance {
     pub repo_path: PathBuf,
     pub first_commit: Option<CommitProvenance>,
@@ -116,7 +117,7 @@ pub struct GitRepoProvenance {
 // CommitProvenance
 // -------------------------------------------------------------------------------------------------
 /// How was a particular Git commit encountered?
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct CommitProvenance {
     pub commit_metadata: CommitMetadata,
 
@@ -134,16 +135,16 @@ pub struct CommitProvenance {
 /// Nosey Parker:
 ///
 /// - A `path` field containing a string
-///
-/// - XXX A `url` string field that is a syntactically-valid URL
-/// - XXX A `time` string field
-/// - XXX A `display` string field
-///
-/// - XXX A `parent_blob` string field with a hex-encoded blob ID that the associated blob was derived from
-/// - XXX A `parent_transform` string field identifying the transform method used to derive the associated blob
-/// - XXX A `parent_start_byte` integer field
-/// - XXX A `parent_end_byte` integer field
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+//
+// - XXX A `url` string field that is a syntactically-valid URL
+// - XXX A `time` string field
+// - XXX A `display` string field
+//
+// - XXX A `parent_blob` string field with a hex-encoded blob ID that the associated blob was derived from
+// - XXX A `parent_transform` string field identifying the transform method used to derive the associated blob
+// - XXX A `parent_start_byte` integer field
+// - XXX A `parent_end_byte` integer field
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ExtendedProvenance(pub serde_json::Value);
 
 impl std::fmt::Display for ExtendedProvenance {

--- a/crates/noseyparker/src/provenance_set.rs
+++ b/crates/noseyparker/src/provenance_set.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::ser::SerializeSeq;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -21,6 +22,21 @@ impl serde::Serialize for ProvenanceSet {
             seq.serialize_element(p)?;
         }
         seq.end()
+    }
+}
+
+impl JsonSchema for ProvenanceSet {
+    fn schema_name() -> String {
+        "ProvenanceSet".into()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let s = <Vec<Provenance>>::json_schema(gen);
+        let mut o = s.into_object();
+        o.array().min_items = Some(1);
+        let md = o.metadata();
+        md.description = Some("A non-empty set of `Provenance` entries".into());
+        schemars::schema::Schema::Object(o)
     }
 }
 

--- a/crates/noseyparker/src/snippet.rs
+++ b/crates/noseyparker/src/snippet.rs
@@ -1,12 +1,13 @@
 use bstr::BString;
 use bstring_serde::BStringLossyUtf8;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 // use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 
 use crate::bstring_escape::Escaped;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct Snippet {
     /// A snippet of the input immediately prior to `content`
     #[serde(with = "BStringLossyUtf8")]

--- a/scripts/create-release.zsh
+++ b/scripts/create-release.zsh
@@ -128,9 +128,9 @@ for SHELL in bash zsh fish powershell elvish; do
 done
 
 ################################################################################
-# JSON Schema generation
+# Copy assets
 ################################################################################
-"$NP" json-schema >"$RELEASE_DIR/share/noseyparker/report-schema.v0.17.json"
+cp -p share/noseyparker/* "$RELEASE_DIR/share/noseyparker/"
 
 ################################################################################
 # Sanity checking

--- a/scripts/create-release.zsh
+++ b/scripts/create-release.zsh
@@ -98,7 +98,7 @@ RELEASE_DIR="release"
 CARGO_BUILD_DIR="target/release"
 
 mkdir "$RELEASE_DIR" || fatal "could not create release directory"
-mkdir "$RELEASE_DIR"/{bin,share,share/completions} || fatal "could not create release directory tree"
+mkdir "$RELEASE_DIR"/{bin,share,share/completions,share/noseyparker} || fatal "could not create release directory tree"
 
 # Build release version of noseyparker into the release dir
 banner "Building release with Cargo"
@@ -126,6 +126,11 @@ fi
 for SHELL in bash zsh fish powershell elvish; do
     "$NP" shell-completions --shell zsh >"$RELEASE_DIR/share/completions/noseyparker.$SHELL"
 done
+
+################################################################################
+# JSON Schema generation
+################################################################################
+"$NP" json-schema >"$RELEASE_DIR/share/noseyparker/report-schema.v0.17.json"
 
 ################################################################################
 # Sanity checking

--- a/share/noseyparker/report-schema.v0.17.json
+++ b/share/noseyparker/report-schema.v0.17.json
@@ -1,0 +1,491 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Array_of_Finding",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/Finding"
+  },
+  "definitions": {
+    "BStringBase64": {
+      "description": "A standard base64-encoded bytestring",
+      "type": "string",
+      "pattern": "[a-zA-Z0-9/+]*={0,2}"
+    },
+    "BlobId": {
+      "description": "A hex-encoded blob ID as computed by Git",
+      "type": "string",
+      "pattern": "[0-9a-f]{40}"
+    },
+    "BlobMetadata": {
+      "description": "Metadata about a blob",
+      "type": "object",
+      "required": [
+        "id",
+        "num_bytes"
+      ],
+      "properties": {
+        "charset": {
+          "description": "The guessed charset of the blob",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "The blob ID this metadata applies to",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BlobId"
+            }
+          ]
+        },
+        "mime_essence": {
+          "description": "The guessed multimedia type of the blob",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "num_bytes": {
+          "description": "The length in bytes of the blob",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "CommitMetadata": {
+      "description": "Metadata about a Git commit.",
+      "type": "object",
+      "required": [
+        "author_email",
+        "author_name",
+        "author_timestamp",
+        "commit_id",
+        "committer_email",
+        "committer_name",
+        "committer_timestamp",
+        "message"
+      ],
+      "properties": {
+        "author_email": {
+          "type": "string"
+        },
+        "author_name": {
+          "type": "string"
+        },
+        "author_timestamp": {
+          "$ref": "#/definitions/Time"
+        },
+        "commit_id": {
+          "$ref": "#/definitions/ObjectId"
+        },
+        "committer_email": {
+          "type": "string"
+        },
+        "committer_name": {
+          "type": "string"
+        },
+        "committer_timestamp": {
+          "$ref": "#/definitions/Time"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "CommitProvenance": {
+      "description": "How was a particular Git commit encountered?",
+      "type": "object",
+      "required": [
+        "blob_path",
+        "commit_metadata"
+      ],
+      "properties": {
+        "blob_path": {
+          "type": "string"
+        },
+        "commit_metadata": {
+          "$ref": "#/definitions/CommitMetadata"
+        }
+      }
+    },
+    "Finding": {
+      "description": "A group of matches that all have the same rule and capture group content",
+      "type": "object",
+      "required": [
+        "finding_id",
+        "groups",
+        "matches",
+        "num_matches",
+        "rule_name",
+        "rule_structural_id",
+        "rule_text_id",
+        "statuses"
+      ],
+      "properties": {
+        "comment": {
+          "description": "A comment assigned to this finding",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "finding_id": {
+          "description": "The content-based finding identifier for this group of matches",
+          "type": "string"
+        },
+        "groups": {
+          "description": "The matched content of all the matches in the group",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Groups"
+            }
+          ]
+        },
+        "matches": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReportMatch"
+          }
+        },
+        "mean_score": {
+          "description": "The mean score in this group of matches",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "num_matches": {
+          "description": "The number of matches in the group",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "rule_name": {
+          "description": "The name of the rule that detected each match",
+          "type": "string"
+        },
+        "rule_structural_id": {
+          "description": "The structural identifier of the rule that detected each match",
+          "type": "string"
+        },
+        "rule_text_id": {
+          "description": "The textual identifier of the rule that detected each match",
+          "type": "string"
+        },
+        "statuses": {
+          "description": "The unique statuses assigned to matches in the group",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Statuses"
+            }
+          ]
+        }
+      }
+    },
+    "Group": {
+      "$ref": "#/definitions/BStringBase64"
+    },
+    "Groups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Group"
+      }
+    },
+    "Location": {
+      "description": "A span, including both the byte- and source-based representation.",
+      "type": "object",
+      "required": [
+        "offset_span",
+        "source_span"
+      ],
+      "properties": {
+        "offset_span": {
+          "$ref": "#/definitions/OffsetSpan"
+        },
+        "source_span": {
+          "$ref": "#/definitions/SourceSpan"
+        }
+      }
+    },
+    "ObjectId": {
+      "description": "A hex-encoded object ID as computed by Git",
+      "type": "string",
+      "pattern": "[0-9a-f]{40}"
+    },
+    "OffsetSpan": {
+      "description": "A non-empty span, defined by two byte offsets. This is a half-open interval. A valid span will have an end value greater than the start value.",
+      "type": "object",
+      "required": [
+        "end",
+        "start"
+      ],
+      "properties": {
+        "end": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "start": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Provenance": {
+      "description": "`Provenance` indicates where a particular blob or match was found when scanning.",
+      "oneOf": [
+        {
+          "description": "Indicates that a blob was seen at a particular file path",
+          "type": "object",
+          "required": [
+            "kind",
+            "path"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "path": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Indicates that a blob was seen in a Git repo, optionally with particular commit provenance info",
+          "type": "object",
+          "required": [
+            "kind",
+            "repo_path"
+          ],
+          "properties": {
+            "first_commit": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/CommitProvenance"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "git_repo"
+              ]
+            },
+            "repo_path": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "An extended provenance entry.\n\nThis is an arbitrary JSON value. If the value is an object containing certain fields, they will be interpreted specially by Nosey Parker:\n\n- A `path` field containing a string",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "extended"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ProvenanceSet": {
+      "description": "A non-empty set of `Provenance` entries",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Provenance"
+      },
+      "minItems": 1
+    },
+    "ReportMatch": {
+      "description": "A match produced by one of Nosey Parker's rules. This corresponds to a single location.",
+      "type": "object",
+      "required": [
+        "blob_id",
+        "blob_metadata",
+        "groups",
+        "location",
+        "provenance",
+        "rule_name",
+        "rule_structural_id",
+        "rule_text_id",
+        "snippet",
+        "structural_id"
+      ],
+      "properties": {
+        "blob_id": {
+          "description": "The blob this match comes from",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BlobId"
+            }
+          ]
+        },
+        "blob_metadata": {
+          "$ref": "#/definitions/BlobMetadata"
+        },
+        "comment": {
+          "description": "An optional comment assigned to the match",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "groups": {
+          "description": "The capture groups",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Groups"
+            }
+          ]
+        },
+        "location": {
+          "description": "The location of the entire matching content",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Location"
+            }
+          ]
+        },
+        "provenance": {
+          "$ref": "#/definitions/ProvenanceSet"
+        },
+        "rule_name": {
+          "description": "The name of the rule that produced this match",
+          "type": "string"
+        },
+        "rule_structural_id": {
+          "description": "The rule that produced this match",
+          "type": "string"
+        },
+        "rule_text_id": {
+          "description": "The text identifier of the rule that produced this match",
+          "type": "string"
+        },
+        "score": {
+          "description": "An optional score assigned to the match",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double",
+          "maximum": 1.0,
+          "minimum": 0.0
+        },
+        "snippet": {
+          "description": "A snippet of the match and surrounding context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Snippet"
+            }
+          ]
+        },
+        "status": {
+          "description": "An optional status assigned to the match",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Status"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "structural_id": {
+          "description": "The unique content-based identifier of this match",
+          "type": "string"
+        }
+      }
+    },
+    "Snippet": {
+      "type": "object",
+      "required": [
+        "after",
+        "before",
+        "matching"
+      ],
+      "properties": {
+        "after": {
+          "description": "A snippet of the input immediately after `content`",
+          "type": "string"
+        },
+        "before": {
+          "description": "A snippet of the input immediately prior to `content`",
+          "type": "string"
+        },
+        "matching": {
+          "description": "The matching input",
+          "type": "string"
+        }
+      }
+    },
+    "SourcePoint": {
+      "description": "A point defined by line and column offsets. Lines are indexed from 1; columns are indexed from 0.",
+      "type": "object",
+      "required": [
+        "column",
+        "line"
+      ],
+      "properties": {
+        "column": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "line": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "SourceSpan": {
+      "description": "A span defined by two source points. This is a clsoed interval.",
+      "type": "object",
+      "required": [
+        "end",
+        "start"
+      ],
+      "properties": {
+        "end": {
+          "$ref": "#/definitions/SourcePoint"
+        },
+        "start": {
+          "$ref": "#/definitions/SourcePoint"
+        }
+      }
+    },
+    "Status": {
+      "description": "A status assigned to a match group",
+      "type": "string",
+      "enum": [
+        "accept",
+        "reject"
+      ]
+    },
+    "Statuses": {
+      "description": "A collection of statuses",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Status"
+      }
+    },
+    "Time": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
This adds a JSON Schema for Nosey Parker's JSON report format. This is implemented using the `schemars` crate to mostly automatically generate the schema from Rust data types.

The schema generation mechanism is accessed using a new `json-schema` top-level command, which is hidden from help. This prints the generated schema to stdout.

The generated schema is included in the release builds.

Fixes #72.