### PR TITLE
Fix shell-completion line in release build script

### DIFF
--- a/scripts/create-release.zsh
+++ b/scripts/create-release.zsh
@@ -132,7 +132,7 @@ fi
 ################################################################################
 banner "Generating shell completion scripts"
 for SHELL in bash zsh fish powershell elvish; do
-    "$NP" generate shell-completions --shell zsh >"${RELEASE_DIR}/share/completions/${NOSEYPARKER}.$SHELL"
+    "$NP" generate shell-completions --shell "$SHELL" >"${RELEASE_DIR}/share/completions/${NOSEYPARKER}.$SHELL"
 done
 
 ################################################################################


### PR DESCRIPTION
Hi there.

While fixing up the Arch User Repo install script (https://aur.archlinux.org/packages/noseyparker) that I maintain for noseyparker today I noticed there is a likely typo in the shell-completion step of the build script.

The script iterates over several shells, but the call to `noseyparker shell-completion` in there is always done with `--shell zsh` so the completion files would be identical I imagine.

This pull request is a simple fix for that.

Best regards,

Mark.