### PR TITLE
Add pre-commit support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.5.0
 
     hooks:
     -   id: check-added-large-files
@@ -11,6 +11,7 @@ repos:
     -   id: check-symlinks
     -   id: check-toml
     -   id: check-yaml
+    -   id: destroyed-symlinks
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+
+    hooks:
+    -   id: check-added-large-files
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-symlinks
+    -   id: check-toml
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+
+    hooks:
+    -   id: fmt
+    -   id: cargo-check
+
+exclude: |
+  (?x)
+  ^
+  ( crates/vectorscan-sys/vectorscan.*        (?# vendored sources )
+  | .*\.snap$                                 (?# insta.rs test cases )
+  ) $

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
     -   id: check-toml
     -   id: check-yaml
     -   id: destroyed-symlinks
-    -   id: end-of-file-fixer
     -   id: trailing-whitespace
 
 -   repo: https://github.com/doublify/pre-commit-rust

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ Developing new regex rules is detailed in a [separate document](docs/RULES.md).
 
 If you are considering making significant code changes, please [open an issue](https://github.com/praetorian-inc/noseyparker/issues/new) or [start a discussion](https://github.com/praetorian-inc/noseyparker/discussions/new/choose) first.
 
+This project has a number of [pre-commit](https://pre-commit.com/) hooks enabled, which you are encouraged to use.
+To install them in your local repo, make sure you have `pre-commit` installed and run:
+```shell
+pre-commit install
+```
+
 
 ## License
 Nosey Parker is licensed under the [Apache License, Version 2.0](LICENSE).

--- a/crates/noseyparker/data/default/builtin/rules/blynk.yml
+++ b/crates/noseyparker/data/default/builtin/rules/blynk.yml
@@ -69,7 +69,7 @@ rules:
     (oa2-client-id_[a-zA-Z0-9_\-]{32})
     (?::|&client_secret=)
     (?:[a-zA-Z0-9_\-]{40})
-  
+
   examples:
   - 'curl -X POST https://fra1.blynk.cloud/oauth2/token?grant_type=client_credentials -u oa2-client-id_zmNtW-D0Toqpz4AZnBLCIlklBrz9ynU-:5uC5Y4Mcvdl5rB56rBmxnvB4DZgiIpcyTPbOoEWp'
   - |
@@ -95,7 +95,7 @@ rules:
   - |
     curl -X POST -u oa2-client-id_zmNtW-D0Toqpz4AZnBLCIlklBrz9ynU-:5uC5Y4Mcvdl5rB56rBmxnvB4DZgiIpcyTPbOoEWp \
     https://fra1.blynk.cloud/oauth2/token?grant_type=client_credentials
-  
+
   references:
   - https://docs.blynk.io/en/blynk.cloud/organization-https-api/authentication
 
@@ -108,7 +108,7 @@ rules:
     (?:oa2-client-id_[a-zA-Z0-9_\-]{32})
     (?::|&client_secret=)
     ([a-zA-Z0-9_\-]{40})
-  
+
   examples:
   - 'curl -X POST https://fra1.blynk.cloud/oauth2/token?grant_type=client_credentials -u oa2-client-id_zmNtW-D0Toqpz4AZnBLCIlklBrz9ynU-:5uC5Y4Mcvdl5rB56rBmxnvB4DZgiIpcyTPbOoEWp'
   - |
@@ -134,6 +134,6 @@ rules:
   - |
     curl -X POST -u oa2-client-id_zmNtW-D0Toqpz4AZnBLCIlklBrz9ynU-:5uC5Y4Mcvdl5rB56rBmxnvB4DZgiIpcyTPbOoEWp \
     https://fra1.blynk.cloud/oauth2/token?grant_type=client_credentials
-  
+
   references:
   - https://docs.blynk.io/en/blynk.cloud/organization-https-api/authentication

--- a/crates/noseyparker/data/default/builtin/rules/dropbox.yml
+++ b/crates/noseyparker/data/default/builtin/rules/dropbox.yml
@@ -13,7 +13,7 @@ rules:
   - 'curl -X POST https://api.dropboxapi.com/2/users/get_current_account --header "Authorization: Bearer sl.hAi61Jx1hs3XlhrnsCxnctrEmxK2Q-UK29hbdxxHyAykldSeHmipBAauxTzuBEIqt2jdyyUZw8kgY3t_ars-PNIPS27ySa1ab22132U3sUuqYTXHzf2XlvMxSesUhkzx2G11_9W1f-eo"'
   # this one comes from dropbox example documentation; ends with a `-`
   - '  "access_token": "sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-",'
-  
+
   references:
   - https://developers.dropbox.com/oauth-guide
   - https://www.dropbox.com/developers/

--- a/crates/noseyparker/data/default/builtin/rules/shopify.yml
+++ b/crates/noseyparker/data/default/builtin/rules/shopify.yml
@@ -16,8 +16,8 @@ rules:
   - https://help.shopify.com/en/manual/domains
 
   examples:
-  - 'handsomestranger.myshopify.com' 
-  - 'store.handsomestranger.myshopify.com' 
+  - 'handsomestranger.myshopify.com'
+  - 'store.handsomestranger.myshopify.com'
 
 
 - name: Shopify App Secret

--- a/crates/noseyparker/data/default/builtin/rules/thingsboard.yml
+++ b/crates/noseyparker/data/default/builtin/rules/thingsboard.yml
@@ -4,7 +4,7 @@ rules:
 # - https://thingsboard.io/docs/paas/reference/mqtt-api/
 # - https://thingsboard.io/docs/reference/mqtt-api/
 
-# FIXME: 
+# FIXME:
 # The default access token follows the format [a-z0-9]{20}. However users may replace it with arbitrary tokens, provided they are between 1 and 32 characters in length.
 # TODO: Update the regex pattern accordingly (currently it matches only the default format).
 # After some research it appears that most (if not all) users utilize the default format so this is a low priority issue.


### PR DESCRIPTION
This adds configuration for [pre-commit](https://pre-commit.com/).
A number of default checks are enabled, and two Rust-specific checks.
