### PR TITLE
Add performance-related Vectorscan features

### DIFF
--- a/crates/noseyparker-cli/Cargo.toml
+++ b/crates/noseyparker-cli/Cargo.toml
@@ -31,6 +31,18 @@ libmagic = ["content-guesser/libmagic"]
 # Compile out `trace`-level log and tracing messages in release builds
 disable_trace = ["log/release_max_level_debug", "tracing/release_max_level_debug"]
 
+# Specialize the build of Vectorscan for the microarchitecture of the build system's CPU.
+# This will result in binary that is not portable to other CPUs.
+vectorscan_cpu_native = ["vectorscan/cpu_native"]
+
+# Specialize the build of Vectorscan to use available SIMD instructions on the build system's CPU.
+# This will result in binary that is not portable to other CPUs.
+vectorscan_simd_specialization = ["vectorscan/simd_specialization"]
+
+# Enable all Vectorscan features that can improve speed but break binary portability.
+vectorscan_fast_nonportable = ["vectorscan_cpu_native", "vectorscan_simd_specialization"]
+
+
 # Enable features that are desirable in a release build
 release = ["disable_trace"]
 

--- a/crates/vectorscan-sys/Cargo.toml
+++ b/crates/vectorscan-sys/Cargo.toml
@@ -11,8 +11,19 @@ version = "0.0.0"
 build = "build.rs"
 
 [features]
-# The `gen` features causes `bindgen` to run to produce the raw Rust bindings to Vectorscan.
+# This feature causes `bindgen` to run to produce the raw Rust bindings to Vectorscan.
 gen = ["bindgen"]
+
+# This feature causes Vectorscan to build using available SIMD
+# microarchitecture support from the build system CPU, such as AVX2, AVX512,
+# SVE, and SVE2. The resulting binary will not be portable to CPUs that lack
+# SIMD support that the build system has.
+simd_specialization = []
+
+# This feature causes Vectorscan to build with code tuned for the
+# microarchitecture of the build system's CPU. The resulting binary will not be
+# portable to CPUs that lack SIMD support that the build system has.
+cpu_native = []
 
 [build-dependencies]
 bindgen = { version = "0.69", optional = true }

--- a/crates/vectorscan/Cargo.toml
+++ b/crates/vectorscan/Cargo.toml
@@ -8,6 +8,18 @@ license = "Apache-2.0 OR MIT"
 name = "vectorscan"
 version = "0.0.0"
 
+[features]
+# Specialize the build of Vectorscan to use available SIMD instructions on the build system's CPU.
+# This will result in binary that is not portable to other CPUs.
+simd_specialization = ["vectorscan-sys/simd_specialization"]
+
+# Specialize the build of Vectorscan for the microarchitecture of the build system's CPU.
+# This will result in binary that is not portable to other CPUs.
+cpu_native = ["vectorscan-sys/cpu_native"]
+
+# Enable all features that can improve speed but break binary portability.
+fast_nonportable = ["cpu_native", "simd_specialization"]
+
 [dependencies]
 bitflags = "2.0"
 foreign-types = "0.5"


### PR DESCRIPTION
The two new features in the `vectorscan` and `vectorscan-sys` crates are `native_cpu` and `simd_specialization`.  These both produce non-portable binaries, as they depend on microarchitectural details of the build system's CPU.

A third convenience feature, `fast_nonportable`, is also included.

These features are plumbed through to the `noseyparker-cli` crate as `vectorscan_native_cpu`, `vectorscan_simd_specialization`, and `vectorscan_fast_nonportable`, and are all disabled by default.