### PR TITLE
Mark SARIF support as experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Additions
+
+- The README now includes several animated GIFs that demonstrate simple example use cases.
+
 ### Changes
 
 - The vendored copy of the Vectorscan regular expression library has been upgraded from version 5.4.8 to 5.4.11.
 - The vendored copy of Boost included in the internal `vectorscan-sys` crate has been removed in favor of using the
   system-provided Boost.
   This change is only relevant to building Nosey Parker from source.
+- SARIF reporting format is now listed as experimental.
+
 
 ## [v0.17.0](https://github.com/praetorian-inc/noseyparker/releases/v0.17.0) (2024-03-05)
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Showing 3/29 occurrences:
 ```
 
 (Note: the findings above are synthetic, invalid secrets.)
-Additional output formats are supported, including JSON, JSON lines, and SARIF, via the `--format=FORMAT` option.
+Additional output formats are supported, including JSON, JSON lines, and SARIF (experimental), via the `--format=FORMAT` option.
 </details>
 
 #### Human-readable text format

--- a/crates/noseyparker-cli/src/args.rs
+++ b/crates/noseyparker-cli/src/args.rs
@@ -963,10 +963,13 @@ pub enum ReportOutputFormat {
     /// This is a sequence of JSON objects, one per line.
     Jsonl,
 
-    /// SARIF format
+    /// SARIF format (experimental)
     ///
     /// This is the Static Analysis Results Interchange Format, a standardized JSON-based format used by many tools.
     /// See the spec at <https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html>.
+    ///
+    /// Support for SARIF output is experimental.
+    /// If you run into problems when using this, please create an issue in the GitHub project: <https://github.com/praetorian-inc/noseyparker>.
     Sarif,
 }
 

--- a/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_report-2.snap
+++ b/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_report-2.snap
@@ -31,7 +31,7 @@ Output Options:
           - human: A text-based format designed for humans
           - json:  Pretty-printed JSON format
           - jsonl: JSON Lines format
-          - sarif: SARIF format
+          - sarif: SARIF format (experimental)
 
       --max-matches <N>
           Limit the number of matches per finding to at most N
@@ -96,4 +96,3 @@ Advanced Global Options:
           
           [default: true]
           [possible values: true, false]
-


### PR DESCRIPTION
SARIF reporting capabilities have been present in Nosey Parker for a while (#33). However, it is not an output format that has been tested very thoroughly. Its current implementation has some known deficiencies (#34).

Additionally, it seems like the SARIF format [has troubles](https://github.com/oasis-tcs/sarif-spec/issues/564) representing findings from tools like Nosey Parker, which look deep in Git history.

This change explicitly notes that SARIF format is "experimental" in Nosey Parker.