### PR TITLE
Set custom scope for Docker build CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,8 +41,8 @@ jobs:
     - name: Build Docker image
       uses: docker/build-push-action@v5
       with:
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ matrix.dockerfile}}
+        cache-to: type=gha,scope=${{ matrix.dockerfile}},mode=max
 
         context: .
         file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
By default, `docker/build-push-action` uses `buildkit` as a scope. In our Docker CI setup, we're building two images at the same time, and it seems that those caches were somehow overwritten in a way that they couldn't be reused. By setting the custom scope, the caching started working. In tests in my personal repo, the building time of the Debian image (one designed to use that caching well) went down from 9m 48s to 5m 41s.