### PR TITLE
Add support for colored backtraces; make tracing spans more useful

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-backtrace"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fd80a270c0671379f388c8204deb6a746bb4eac8a6c03fe2460b2c0127ea0"
+dependencies = [
+ "backtrace",
+ "termcolor",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2512,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
+ "color-backtrace",
  "console",
  "content-guesser",
  "crossbeam-channel",
@@ -3697,6 +3708,15 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/crates/noseyparker-cli/Cargo.toml
+++ b/crates/noseyparker-cli/Cargo.toml
@@ -44,10 +44,12 @@ vectorscan_fast_nonportable = ["vectorscan_cpu_native", "vectorscan_simd_special
 
 mimalloc = ["dep:mimalloc", "dep:libmimalloc-sys"]
 
+color_backtrace = ["dep:color-backtrace"]
+
 # Enable features that are desirable in a release build
 release = ["disable_trace", "mimalloc"]
 
-default = ["mimalloc"]
+default = ["mimalloc", "color_backtrace"]
 
 
 [build-dependencies]
@@ -61,6 +63,7 @@ bstr = { version = "1.0" }
 clap = { version = "4.3", features = ["cargo", "derive", "env", "unicode", "wrap_help"] }
 clap_complete = "4.4"
 clap_mangen = "0.2"
+color-backtrace = { version = "0.6", optional = true }
 console = "0.15"
 content-guesser = { path = "../content-guesser" }
 crossbeam-channel = "0.5"

--- a/crates/noseyparker-cli/src/main.rs
+++ b/crates/noseyparker-cli/src/main.rs
@@ -88,8 +88,16 @@ fn configure_backtraces(global_args: &GlobalArgs) {
     if global_args.advanced.enable_backtraces {
         // Print a stack trace in case of panic.
         // This should have no overhead in normal execution.
-        std::env::set_var("RUST_BACKTRACE", "1");
+        let val = if cfg!(feature = "color_backtrace") {
+            "full"
+        } else {
+            "1"
+        };
+        std::env::set_var("RUST_BACKTRACE", val);
     }
+
+    #[cfg(feature = "color_backtrace")]
+    color_backtrace::install();
 }
 
 fn try_main(args: &CommandLineArgs) -> Result<()> {


### PR DESCRIPTION
This enables colored panic backtraces by default, using the [colored-backtrace](https://crates.io/crates/color-backtrace) crate. This color-codes stack frames by runtime code / library code / user code, includes source snippets, and is overall more legible than default backtraces.

This new support is behind the new `colored_backtrace` feature flag, which is enabled by default.

Also in this: make the `tracing` spans produced when scanning more useful.