### PR TITLE
Fix malformed Git timestamp crash bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixes
 
+- A rare crash when parsing malformed Git commit timestamps has been fixed by updating the `gix-date` dependency.
+
 - Upon `noseyparker` startup, if resource limits cannot be adjusted, instead of crashing, a warning is printed and the process attempts to continue ([#170](https://github.com/praetorian-inc/noseyparker/issues/170)).
 
 - The prepackaged releases and binaries produced by the default settings of `cargo build` should now be more portable across microarchitectures ([#175](https://github.com/praetorian-inc/noseyparker/pull/175)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180b130a4a41870edfbd36ce4169c7090bca70e195da783dea088dd973daa59c"
+checksum = "367ee9093b0c2b04fd04c5c7c8b6a1082713534eab537597ae343663a518fa99"
 dependencies = [
  "bstr",
  "itoa",


### PR DESCRIPTION
This fixes a rare bug that could cause Nosey Parker to crash when scanning when encountering a malformed timestamp in a Git commit object. The fix comes from updating the `gix-date` dependency. See https://github.com/Byron/gitoxide/issues/1367.