### PR TITLE
General support - PATs in git password field

### DIFF
--- a/crates/noseyparker/src/git_binary.rs
+++ b/crates/noseyparker/src/git_binary.rs
@@ -32,7 +32,7 @@ impl Git {
                 "-c",
                 r#"credential.helper="#,
                 "-c",
-                r#"credential.helper=!_ghcreds() { echo username="$NP_GITHUB_TOKEN"; echo password=; }; _ghcreds"#,
+                r#"credential.helper=!_ghcreds() { echo username="noseyparker"; echo password="$NP_GITHUB_TOKEN"; }; _ghcreds"#,
             ].iter().map(|s| s.to_string()).collect()
         // } else {
         //     vec![]


### PR DESCRIPTION
This small PR modifies the git credential helper to pass the PAT stored in the `$NP_GITHUB_TOKEN` env variable as the git password field rather than the username. In my testing, this change makes it possible to clone private GitLab repos with the `--git-url` argument as long as the GitLab PAT is set in the `$NP_GITHUB_TOKEN` env variable.

My testing also shows that cloning private GitHub repos with the `--git-url` argument still works as expected after this change.