### PR TITLE
Improve `summarize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   Having the debug symbols available makes stack traces more useful in the rare event of a crash.
   The Alpine-based Docker image does not include these debug symbols, as its point of existing is to provide a small distribution.
 
+- The `summarize` command now includes additional columns for the assigned finding status ([#196](https://github.com/praetorian-inc/noseyparker/pull/196)).
 
 ### Changes
 

--- a/crates/noseyparker-cli/src/args.rs
+++ b/crates/noseyparker-cli/src/args.rs
@@ -224,6 +224,24 @@ pub enum Command {
     Scan(ScanArgs),
 
     /// Summarize scan findings
+    ///
+    /// Findings are summarized in tabular form.
+    /// The default `human` format prints a table of findings with one row for each rule that produced findings.
+    /// The table has several columns:
+    ///
+    /// - Rule: the name of the rule
+    ///
+    /// - Findings: the number of findings, i.e., the number of distinct match group values produced by the rule
+    ///
+    /// - Matches: the number of individual matches
+    ///
+    /// - Accepted: the number of findings whose matches have `accept` status
+    ///
+    /// - Rejected: the number of findings whose matches have `reject` status
+    ///
+    /// - Mixed: the number of findings whose matches have a mix of `accept` and `reject` status
+    ///
+    /// - Unlabeled: the number of findings whose matches have no status at all
     #[command(display_order = 2, alias = "summarise")]
     Summarize(SummarizeArgs),
 

--- a/crates/noseyparker-cli/src/cmd_scan.rs
+++ b/crates/noseyparker-cli/src/cmd_scan.rs
@@ -657,10 +657,13 @@ pub fn run(global_args: &args::GlobalArgs, args: &args::ScanArgs) -> Result<()> 
         }
 
         if num_matches > 0 {
-            let matches_summary = datastore.get_summary()?;
-            let matches_table = crate::cmd_summarize::summary_table(&matches_summary);
+            let summary = datastore
+                .get_summary()
+                .context("Failed to get finding summary")
+                .unwrap();
+            let table = crate::cmd_summarize::summary_table(&summary);
             println!();
-            matches_table.print_tty(global_args.use_color(std::io::stdout()))?;
+            table.print_tty(global_args.use_color(std::io::stdout()))?;
         }
 
         println!("\nRun the `report` command next to show finding details.");

--- a/crates/noseyparker-cli/src/cmd_summarize.rs
+++ b/crates/noseyparker-cli/src/cmd_summarize.rs
@@ -53,7 +53,11 @@ pub fn run(global_args: &GlobalArgs, args: &SummarizeArgs) -> Result<()> {
         .output_args
         .get_writer()
         .context("Failed to get output writer")?;
-    FindingSummaryReporter(datastore.get_summary()?).report(args.output_args.format, output)
+    let summary = datastore
+        .get_summary()
+        .context("Failed to get finding summary")
+        .unwrap();
+    FindingSummaryReporter(summary).report(args.output_args.format, output)
 }
 
 pub fn summary_table(summary: &FindingSummary) -> prettytable::Table {
@@ -73,11 +77,23 @@ pub fn summary_table(summary: &FindingSummary) -> prettytable::Table {
             row![
                  l -> &e.rule_name,
                  r -> HumanCount(e.distinct_count.try_into().unwrap()),
-                 r -> HumanCount(e.total_count.try_into().unwrap())
+                 r -> HumanCount(e.total_count.try_into().unwrap()),
+                 r -> HumanCount(e.accept_count.try_into().unwrap()),
+                 r -> HumanCount(e.reject_count.try_into().unwrap()),
+                 r -> HumanCount(e.mixed_count.try_into().unwrap()),
+                 r -> HumanCount(e.unlabeled_count.try_into().unwrap()),
             ]
         })
         .collect();
     table.set_format(f);
-    table.set_titles(row![lb -> "Rule", cb -> "Total Findings", cb -> "Total Matches"]);
+    table.set_titles(row![
+        lb -> "Rule",
+        cb -> "Findings",
+        cb -> "Matches",
+        cb -> "Accepted",
+        cb -> "Rejected",
+        cb -> "Mixed",
+        cb -> "Unlabeled",
+    ]);
     table
 }

--- a/crates/noseyparker-cli/tests/datastore/snapshots/test_noseyparker__datastore__export_empty-2.snap
+++ b/crates/noseyparker-cli/tests/datastore/snapshots/test_noseyparker__datastore__export_empty-2.snap
@@ -2,5 +2,5 @@
 source: crates/noseyparker-cli/tests/datastore/mod.rs
 expression: stdout
 ---
- Rule   Total Findings   Total Matches 
-───────────────────────────────────────
+ Rule   Findings   Matches   Accepted   Rejected   Mixed   Unlabeled 
+─────────────────────────────────────────────────────────────────────

--- a/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_summarize-2.snap
+++ b/crates/noseyparker-cli/tests/help/snapshots/test_noseyparker__help__help_summarize-2.snap
@@ -4,6 +4,24 @@ expression: stdout
 ---
 Summarize scan findings
 
+Findings are summarized in tabular form. The default `human` format prints a table of findings with
+one row for each rule that produced findings. The table has several columns:
+
+- Rule: the name of the rule
+
+- Findings: the number of findings, i.e., the number of distinct match group values produced by the
+rule
+
+- Matches: the number of individual matches
+
+- Accepted: the number of findings whose matches have `accept` status
+
+- Rejected: the number of findings whose matches have `reject` status
+
+- Mixed: the number of findings whose matches have a mix of `accept` and `reject` status
+
+- Unlabeled: the number of findings whose matches have no status at all
+
 Usage: noseyparker summarize [OPTIONS]
 
 Options:

--- a/crates/noseyparker-cli/tests/scan/appmaker/snapshots/test_noseyparker__scan__appmaker__scan_workflow_from_git_url-2.snap
+++ b/crates/noseyparker-cli/tests/scan/appmaker/snapshots/test_noseyparker__scan__appmaker__scan_workflow_from_git_url-2.snap
@@ -2,11 +2,11 @@
 source: crates/noseyparker-cli/tests/scan/appmaker/mod.rs
 expression: stdout
 ---
- Rule                         Total Findings   Total Matches 
-─────────────────────────────────────────────────────────────
- AWS API Key                               3               3 
- AWS S3 Bucket (path style)                3              13 
- Amazon Resource Name                      3               3 
- Generic Secret                            3               3 
- AWS API Credentials                       1               1 
- AWS Secret Access Key                     1               1
+ Rule                         Findings   Matches   Accepted   Rejected   Mixed   Unlabeled 
+───────────────────────────────────────────────────────────────────────────────────────────
+ AWS API Credentials                 1         1          0          0       0           1 
+ AWS API Key                         3         3          0          0       0           3 
+ AWS S3 Bucket (path style)          3        13          0          0       0           3 
+ AWS Secret Access Key               1         1          0          0       0           1 
+ Amazon Resource Name                3         3          0          0       0           3 
+ Generic Secret                      3         3          0          0       0           3

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_secrets1-2.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_secrets1-2.snap
@@ -2,8 +2,6 @@
 source: crates/noseyparker-cli/tests/scan/basic/mod.rs
 expression: stdout
 ---
-
- Rule                           Total Findings   Total Matches 
-───────────────────────────────────────────────────────────────
- GitHub Personal Access Token                1               1 
-
+ Rule                           Findings   Matches   Accepted   Rejected   Mixed   Unlabeled 
+─────────────────────────────────────────────────────────────────────────────────────────────
+ GitHub Personal Access Token          1         1          0          0       0           1

--- a/crates/noseyparker-cli/tests/scan/snippet_length/snapshots/test_noseyparker__scan__snippet_length__scan_changing_snippet_length-2.snap
+++ b/crates/noseyparker-cli/tests/scan/snippet_length/snapshots/test_noseyparker__scan__snippet_length__scan_changing_snippet_length-2.snap
@@ -2,8 +2,6 @@
 source: crates/noseyparker-cli/tests/scan/snippet_length/mod.rs
 expression: stdout
 ---
-
- Rule                           Total Findings   Total Matches 
-───────────────────────────────────────────────────────────────
- GitHub Personal Access Token                1               1 
-
+ Rule                           Findings   Matches   Accepted   Rejected   Mixed   Unlabeled 
+─────────────────────────────────────────────────────────────────────────────────────────────
+ GitHub Personal Access Token          1         1          0          0       0           1

--- a/crates/noseyparker-cli/tests/scan/snippet_length/snapshots/test_noseyparker__scan__snippet_length__scan_changing_snippet_length-9.snap
+++ b/crates/noseyparker-cli/tests/scan/snippet_length/snapshots/test_noseyparker__scan__snippet_length__scan_changing_snippet_length-9.snap
@@ -2,8 +2,6 @@
 source: crates/noseyparker-cli/tests/scan/snippet_length/mod.rs
 expression: stdout
 ---
-
- Rule                           Total Findings   Total Matches 
-───────────────────────────────────────────────────────────────
- GitHub Personal Access Token                1               1 
-
+ Rule                           Findings   Matches   Accepted   Rejected   Mixed   Unlabeled 
+─────────────────────────────────────────────────────────────────────────────────────────────
+ GitHub Personal Access Token          1         1          0          0       0           1

--- a/crates/noseyparker/src/datastore/finding_summary.rs
+++ b/crates/noseyparker/src/datastore/finding_summary.rs
@@ -10,16 +10,25 @@ pub struct FindingSummary(pub Vec<FindingSummaryEntry>);
 
 #[derive(Serialize)]
 pub struct FindingSummaryEntry {
+    /// The rule name of this entry
     pub rule_name: String,
-    pub distinct_count: usize,
-    pub total_count: usize,
-}
 
-impl std::fmt::Display for FindingSummary {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for entry in self.0.iter() {
-            writeln!(f, "{}: {} ({})", entry.rule_name, entry.distinct_count, entry.total_count)?;
-        }
-        Ok(())
-    }
+    /// The number of findings with this rule
+    pub distinct_count: usize,
+
+    /// The number of matches with this rule
+    pub total_count: usize,
+
+    /// The number of findings with this rule with the `accept` status
+    pub accept_count: usize,
+
+    /// The number of findings with this rule with the `reject` status
+    pub reject_count: usize,
+
+    /// The number of findings with this rule with a mixed status, i.e., both `reject` and `accept`
+    /// status
+    pub mixed_count: usize,
+
+    /// The number of findings with this rule that have no assigned status
+    pub unlabeled_count: usize,
 }


### PR DESCRIPTION
- Add columns for status labels

- Improve error handling of summary-producing operations (these should not ever fail under normal circumstances, so give a stack trace when they do)

- Add more detailed command-level help to `summarize --help`