### PR TITLE
Use new Linux arm64 runners in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,30 @@ jobs:
           check_docs: true
           run_tests: true
 
+        - name: ubuntu-22.04.arm64.stable.release
+          os: ubuntu-22.04-arm64-8-core
+          rust: stable
+          profile: release
+          features: release
+          install_dependencies: |
+            sudo apt-get install zsh libboost-all-dev
+          cpu_info_cmd: 'cat /proc/cpuinfo'
+
+          check_docs: false
+          run_tests: true
+
+        - name: ubuntu-24.04.arm64.stable.test
+          os: ubuntu-24.04-arm64-8-core
+          rust: stable
+          profile: test
+          features:
+          install_dependencies: |
+            sudo apt-get install zsh libboost-all-dev
+          cpu_info_cmd: 'cat /proc/cpuinfo'
+
+          check_docs: true
+          run_tests: true
+
         - name: macos-12.x86_64.stable.test
           os: macos-12
           rust: stable

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -119,6 +119,12 @@ jobs:
           install_dependencies: |
             sudo apt-get install zsh libboost-all-dev
 
+        - build: ubuntu-22.04.arm64
+          os: ubuntu-22.04-arm64-8-core
+          rust: stable
+          install_dependencies: |
+            sudo apt-get install zsh libboost-all-dev
+
         - build: macos-13.x86_64
           os: macos-13
           rust: stable


### PR DESCRIPTION
GitHub Actions now offers ARM64-based hosted runners in public beta:
- https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/
- https://github.blog/changelog/2024-06-24-github-actions-ubuntu-24-04-image-now-available-for-arm64-runners/

We've set up two ARM64-flavored runners at Praetorian: `ubuntu-22.04` and an `ubuntu-24.04`.

This change uses those runners for CI and release builds as additional targets.