### PR TITLE
Fix startup assertion failure on <4GiB RAM machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project aspires to use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Fixes
+
+- Nosey Parker no longer crashes upon startup when running in environments with less than 4 GiB of RAM.
+
+
 ## [v0.18.0](https://github.com/praetorian-inc/noseyparker/releases/v0.18.0) (2024-06-27)
 
 ### Additions

--- a/crates/noseyparker-cli/src/args.rs
+++ b/crates/noseyparker-cli/src/args.rs
@@ -103,7 +103,8 @@ fn default_scan_jobs() -> usize {
     match (std::thread::available_parallelism(), *RAM_GB) {
         (Ok(v), Some(ram_gb)) => {
             let n: usize = v.into();
-            n.clamp(1, (ram_gb / 4.0).floor() as usize)
+            let max_n = (ram_gb / 4.0).ceil().max(1.0) as usize;
+            n.clamp(1, max_n)
         }
         (Ok(v), None) => v.into(),
         (Err(_e), _) => 1,


### PR DESCRIPTION
The v0.18.0 release crashes upon startup when running in an environment with less that 4GiB of RAM. The crash is an assertion failure from the `std::cmp::Ord::clamp` function when it is called with invalid arguments (i.e., `min > max`).

This crashing behavior was introduced in #174.