### PR TITLE
Update mimalloc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,9 +2304,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.35"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
 dependencies = [
  "cc",
  "libc",
@@ -2430,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.39"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/crates/noseyparker-cli/Cargo.toml
+++ b/crates/noseyparker-cli/Cargo.toml
@@ -73,9 +73,9 @@ indicatif = { version = "0.17", features = ["improved_unicode"] }
 indoc = "2.0"
 input-enumerator = { path = "../input-enumerator" }
 lazy_static = "1.4"
-libmimalloc-sys = { version = "=0.1.35", optional = true }
+libmimalloc-sys = { version = "0.1.39", optional = true }
 log = { version = "0.4", optional = true }
-mimalloc = { version = "=0.1.39", optional = true }
+mimalloc = { version = "0.1.43", optional = true }
 mime = "0.3"
 noseyparker = { path = "../noseyparker" }
 noseyparker-digest = { path = "../noseyparker-digest" }


### PR DESCRIPTION
Previously, the version had been pinned to an older one because recent mimalloc changes broke the build on some platforms.