### PR TITLE
Overhaul Docker CI builder

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -95,7 +95,10 @@ jobs:
 
     - name: Inspect Docker image
       run: |
-        docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.metadata.outputs.version }}
+        docker buildx imagetools inspect ${{ matrix.image }}:sha256@${{ steps.build.outputs.digest }}
+
+    - name: Test Docker image
+      run: docker run --rm "${{ matrix.image }}:sha256@${{ steps.build.outputs.digest }}" --version
 
     - name: Export digest
       run: |
@@ -179,9 +182,6 @@ jobs:
     - name: Inspect Docker image
       run: |
         docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.metadata.outputs.version }}
-
-    - name: Test Docker image
-      run: docker run --rm "${{ matrix.image }}:${{ steps.metadata.outputs.version }}" --version
 
     - name: Push the Docker image to `edge`
       if: github.event_name == 'push' && github.ref_name == 'main'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: default
+        - name: debian
           platform: linux/amd64
           dockerfile: Dockerfile
           image: ghcr.io/${{ github.repository }}
           runs-on: ubuntu-22.04
 
-        - name: default
+        - name: debian
           platform: linux/arm64
           dockerfile: Dockerfile
           image: ghcr.io/${{ github.repository }}
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: default
+        - name: debian
           image: ghcr.io/${{ github.repository }}
 
         - name: alpine
@@ -100,6 +100,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+
+    name: Docker (${{ matrix.name }})
 
     steps:
     - name: Download digests

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -152,28 +152,11 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    # What's going on here?? A few cursed things.
-    #
-    # A merged multiplatform image from the individual single-platform images
-    # is constructed using the `docker buildx imagetools create` command.
-    #
-    # This takes a list of source manifests to combine. That list is
-    # constructed using the `jq -cr '.tags...` command and the `printf`
-    # command.
-    #
-    # The image metadata is propagated via munging the relevant annotations
-    # from $DOCKER_METADATA_OUTPUT_JSON (set by the `metadata` step) into the
-    # appropriate form for the `docker buildx imagetools create` command.
-    #
-    # See here for more details:
-    # https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/
-    #
     - name: Create and push merged image
       working-directory: /tmp/digests
       run: |
-        jq -cr '.annotations | map("--annotation=manifest-descriptor:" + (. | sub("^manifest:"; ""))) | join("\u0000")' <<< "$DOCKER_METADATA_OUTPUT_JSON" |
         xargs -0 docker buildx imagetools create \
-          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          "$DOCKER_METADATA_OUTPUT_TAGS" \
           $(printf '${{ matrix.image }}@sha256:%s ' *)
 
     - name: Inspect Docker image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,8 @@ on:
     branches: [ "main" ]
 
 jobs:
+
+  # build single-platform docker images on native runners
   build:
     strategy:
       matrix:
@@ -57,7 +59,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Docker metadata
+    - name: Collect Docker metadata
       id: metadata
       uses: docker/metadata-action@v5
       with:
@@ -76,7 +78,9 @@ jobs:
 
         platforms: ${{ matrix.platform }}
 
-        labels: ${{ steps.meta.outputs.labels }}
+        # don't specify 'tags' here (error "get can't push tagged ref by digest")
+
+        labels: ${{ steps.metadata.outputs.labels }}
         # labels: |
         #   org.opencontainers.image.title=${{ github.event.repository.name }}
         #   org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -101,7 +105,7 @@ jobs:
         if-no-files-found: error
         retention-days: 1
 
-
+  # merge single-platform images into multiplatform images
   merge:
     strategy:
       matrix:
@@ -130,7 +134,7 @@ jobs:
     - name: Set up Docker buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Docker metadata
+    - name: Collect Docker metadata
       id: metadata
       uses: docker/metadata-action@v5
       with:
@@ -147,17 +151,18 @@ jobs:
     - name: Create manifest list and push
       working-directory: /tmp/digests
       run: |
-        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        docker buildx imagetools create \
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf '${{ matrix.image }}@sha256:%s ' *)
 
-    - name: Inspect image
+    - name: Inspect Docker image
       run: |
         docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.metadata.outputs.version }}
 
-    - name: Test the Docker image
+    - name: Test Docker image
       run: docker run --rm "${{ matrix.image }}:${{ steps.metadata.outputs.version }}" --version
 
-    - name: Push the image to `edge`
+    - name: Push the Docker image to `edge`
       if: github.event_name == 'push' && github.ref_name == 'main'
       run: |
         docker push "${{ matrix.image }}:edge"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,43 +11,56 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: debian
+        - name: default
+          platform: linux/amd64
           dockerfile: Dockerfile
           image: ghcr.io/${{ github.repository }}
+          runs-on: ubuntu-22.04
+
+        - name: default
+          platform: linux/arm64
+          dockerfile: Dockerfile
+          image: ghcr.io/${{ github.repository }}
+          runs-on: ubuntu-22.04-arm64-8-core
 
         - name: alpine
+          platform: linux/amd64
           dockerfile: Dockerfile.alpine
           image: ghcr.io/${{ github.repository }}-alpine
+          runs-on: ubuntu-22.04
 
-    name: Docker (${{ matrix.name }})
-    runs-on: ubuntu-22.04
+        - name: alpine
+          platform: linux/arm64
+          dockerfile: Dockerfile.alpine
+          image: ghcr.io/${{ github.repository }}-alpine
+          runs-on: ubuntu-22.04-arm64-8-core
+
+    name: Docker (${{ matrix.platform }} ${{ matrix.name }})
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v4
 
-    # The following for multi-platform build; disabled here because it takes so long; see #39.
-    #
-    # The docker image built for noseyparker releases is done in the
-    # `release-artifacts.yml` file.
-    #
-    # - uses: docker/setup-qemu-action@v2
-
     - uses: docker/setup-buildx-action@v3
 
-    - name: Build Docker image
-      uses: docker/build-push-action@v5
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platform }}
+        # replace slashes in platform with dashes
+        echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+    - name: Build and push by digest
+      uses: docker/build-push-action@v6
       with:
         cache-from: type=gha,scope=${{ matrix.dockerfile }}
         cache-to: type=gha,scope=${{ matrix.dockerfile }},mode=min
 
         context: .
+
+        platforms: ${{ matrix.platform }}
+
         file: ${{ matrix.dockerfile }}
         tags: ${{ matrix.image }}:edge
-        push: false
-        # For multi-platform builds
-        # platforms: linux/amd64,linux/arm64
-        load: true
-        pull: true
 
         labels: |
           org.opencontainers.image.title=${{ github.event.repository.name }}
@@ -57,8 +70,67 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
           org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
 
+        outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+
     - name: Test the Docker image
       run: docker run --rm "${{ matrix.image }}:edge" --version
+
+    - name: Export digest
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+
+  merge:
+    strategy:
+      matrix:
+        include:
+        - name: default
+          image: ghcr.io/${{ github.repository }}
+
+        - name: alpine
+          image: ghcr.io/${{ github.repository }}-alpine
+
+
+    runs-on: ubuntu-latest
+    needs:
+      - build
+
+    steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests
+        pattern: digests-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ matrix.image }}
+
+    - name: Create manifest list and push
+      working-directory: /tmp/digests
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ matrix.image }}@sha256:%s ' *)
+
+    - name: Inspect image
+      run: |
+        docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.meta.outputs.version }}
 
     # We need to authenticate with GHCR both to push the tagged image for the
     # `main` branch

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -78,9 +78,6 @@ jobs:
       uses: docker/build-push-action@v6
       id: build
       with:
-        cache-from: type=gha,scope=${{ matrix.dockerfile }}
-        cache-to: type=gha,scope=${{ matrix.dockerfile }},mode=min
-
         context: .
 
         file: ${{ matrix.dockerfile }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -155,6 +155,7 @@ jobs:
     - name: Create and push merged image
       working-directory: /tmp/digests
       run: |
+        jq -cr '.annotations | map("--annotation=index:" + (. | sub("^manifest:"; ""))) | join("\u0000")' <<< "$DOCKER_METADATA_OUTPUT_JSON" |
         xargs -0 docker buildx imagetools create \
           $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf '${{ matrix.image }}@sha256:%s ' *)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,3 +1,15 @@
+# This workflow builds multiplatform Nosey Parker Docker images for both the Debian and
+# Alpine varieties.
+#
+# For each variety, it uses a native-hardware runner to build the individual
+# Docker images, and then merges them into a multiplatform image.
+#
+# This approach is taken instead of using QEMU, since a QEMU build of Nosey
+# Parker takes several hours. Using native runners instead takes a few minutes.
+#
+# This was adapted from the Docker documentation site:
+# https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+#
 name: Docker
 
 on:
@@ -142,6 +154,22 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    # What's going on here?? A few cursed things.
+    #
+    # A merged multiplatform image from the individual single-platform images
+    # is constructed using the `docker buildx imagetools create` command.
+    #
+    # This takes a list of source manifests to combine. That list is
+    # constructed using the `jq -cr '.tags...` command and the `printf`
+    # command.
+    #
+    # The image metadata is propagated via munging the relevant annotations
+    # from $DOCKER_METADATA_OUTPUT_JSON (set by the `metadata` step) into the
+    # appropriate form for the `docker buildx imagetools create` command.
+    #
+    # See here for more details:
+    # https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/
+    #
     - name: Create and push merged image
       working-directory: /tmp/digests
       run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,6 +49,14 @@ jobs:
         # replace slashes in platform with dashes
         echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
+    # We need to authenticate with GHCR both to push the image by digest
+    - name: Authenticate with GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build and push by digest
       uses: docker/build-push-action@v6
       with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -155,8 +155,7 @@ jobs:
     - name: Create and push merged image
       working-directory: /tmp/digests
       run: |
-        jq -cr '.annotations | map("--annotation=index:" + (. | sub("^manifest:"; ""))) | join("\u0000")' <<< "$DOCKER_METADATA_OUTPUT_JSON" |
-        xargs -0 docker buildx imagetools create \
+        docker buildx imagetools create \
           $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf '${{ matrix.image }}@sha256:%s ' *)
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -145,8 +145,8 @@ jobs:
     - name: Create and push merged image
       working-directory: /tmp/digests
       run: |
-        docker buildx imagetools create \
-          $(jq -cr '.annotations | map("--annotation \"manifest-descriptor:" + (. | sub("^manifest:"; "")) + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        jq -cr '.annotations | map("--annotation=manifest-descriptor:" + (. | sub("^manifest:"; ""))) | join("\u0000")' <<< "$DOCKER_METADATA_OUTPUT_JSON" |
+        xargs -0 docker buildx imagetools create \
           $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf '${{ matrix.image }}@sha256:%s ' *)
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  REGISTRY: ghcr.io
-
 jobs:
 
   # build single-platform docker images on native runners
@@ -19,25 +16,25 @@ jobs:
         - base: debian
           platform: linux/amd64
           dockerfile: Dockerfile
-          image: ${{ env.REGISTRY }}/${{ github.repository }}
+          image: ghcr.io/${{ github.repository }}
           runs-on: ubuntu-22.04
 
         - base: debian
           platform: linux/arm64
           dockerfile: Dockerfile
-          image: ${{ env.REGISTRY }}/${{ github.repository }}
+          image: ghcr.io/${{ github.repository }}
           runs-on: ubuntu-22.04-arm64-8-core
 
         - base: alpine
           platform: linux/amd64
           dockerfile: Dockerfile.alpine
-          image: ${{ env.REGISTRY }}/${{ github.repository }}-alpine
+          image: ghcr.io/${{ github.repository }}-alpine
           runs-on: ubuntu-22.04
 
         - base: alpine
           platform: linux/arm64
           dockerfile: Dockerfile.alpine
-          image: ${{ env.REGISTRY }}/${{ github.repository }}-alpine
+          image: ghcr.io/${{ github.repository }}-alpine
           runs-on: ubuntu-22.04-arm64-8-core
 
     name: Docker (${{ matrix.platform }} ${{ matrix.base }})
@@ -57,7 +54,7 @@ jobs:
     - name: Authenticate with Docker registry
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -110,10 +107,10 @@ jobs:
       matrix:
         include:
         - base: debian
-          image: ${{ env.REGISTRY }}/${{ github.repository }}
+          image: ghcr.io/${{ github.repository }}
 
         - base: alpine
-          image: ${{ env.REGISTRY }}/${{ github.repository }}-alpine
+          image: ghcr.io/${{ github.repository }}-alpine
 
 
     runs-on: ubuntu-latest
@@ -141,7 +138,7 @@ jobs:
     - name: Authenticate with Docker registry
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -136,6 +136,14 @@ jobs:
       with:
         images: ${{ matrix.image }}
 
+    # We need to authenticate with GHCR to push
+    - name: Authenticate with GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create manifest list and push
       working-directory: /tmp/digests
       run: |
@@ -148,16 +156,6 @@ jobs:
 
     - name: Test the Docker image
       run: docker run --rm "${{ matrix.image }}:${{ steps.metadata.outputs.version }}" --version
-
-    # We need to authenticate with GHCR both to push the tagged image for the
-    # `main` branch
-    - name: Authenticate with GitHub Container Registry
-      if: github.event_name == 'push' && github.ref_name == 'main'
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push the image to `edge`
       if: github.event_name == 'push' && github.ref_name == 'main'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -60,7 +60,6 @@ jobs:
         platforms: ${{ matrix.platform }}
 
         file: ${{ matrix.dockerfile }}
-        tags: ${{ matrix.image }}:edge
 
         labels: |
           org.opencontainers.image.title=${{ github.event.repository.name }}
@@ -71,9 +70,6 @@ jobs:
           org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
 
         outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
-
-    - name: Test the Docker image
-      run: docker run --rm "${{ matrix.image }}:edge" --version
 
     - name: Export digest
       run: |
@@ -131,6 +127,9 @@ jobs:
     - name: Inspect image
       run: |
         docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.meta.outputs.version }}
+
+    - name: Test the Docker image
+      run: docker run --rm "${{ matrix.image }}:${{ steps.meta.outputs.version }}" --version
 
     # We need to authenticate with GHCR both to push the tagged image for the
     # `main` branch

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -167,4 +167,4 @@ jobs:
     - name: Push the Docker image to `edge`
       if: github.event_name == 'push' && github.ref_name == 'main'
       run: |
-        docker push "${{ matrix.image }}:edge"
+        docker buildx imagetools create -t "${{ matrix.image }}:edge" "${{ matrix.image }}:${{ steps.metadata.outputs.version }}"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
 
   # build single-platform docker images on native runners
@@ -16,25 +19,25 @@ jobs:
         - base: debian
           platform: linux/amd64
           dockerfile: Dockerfile
-          image: ghcr.io/${{ github.repository }}
+          image: ${{ env.REGISTRY }}/${{ github.repository }}
           runs-on: ubuntu-22.04
 
         - base: debian
           platform: linux/arm64
           dockerfile: Dockerfile
-          image: ghcr.io/${{ github.repository }}
+          image: ${{ env.REGISTRY }}/${{ github.repository }}
           runs-on: ubuntu-22.04-arm64-8-core
 
         - base: alpine
           platform: linux/amd64
           dockerfile: Dockerfile.alpine
-          image: ghcr.io/${{ github.repository }}-alpine
+          image: ${{ env.REGISTRY }}/${{ github.repository }}-alpine
           runs-on: ubuntu-22.04
 
         - base: alpine
           platform: linux/arm64
           dockerfile: Dockerfile.alpine
-          image: ghcr.io/${{ github.repository }}-alpine
+          image: ${{ env.REGISTRY }}/${{ github.repository }}-alpine
           runs-on: ubuntu-22.04-arm64-8-core
 
     name: Docker (${{ matrix.platform }} ${{ matrix.base }})
@@ -51,11 +54,10 @@ jobs:
         # replace slashes in platform with dashes
         echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
-    # We need to authenticate with GHCR both to push the image by digest
-    - name: Authenticate with GitHub Container Registry
+    - name: Authenticate with Docker registry
       uses: docker/login-action@v3
       with:
-        registry: ghcr.io
+        registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -81,15 +83,12 @@ jobs:
         # don't specify 'tags' here (error "get can't push tagged ref by digest")
 
         labels: ${{ steps.metadata.outputs.labels }}
-        # labels: |
-        #   org.opencontainers.image.title=${{ github.event.repository.name }}
-        #   org.opencontainers.image.description=${{ github.event.repository.description }}
-        #   org.opencontainers.image.url=${{ github.event.repository.html_url }}
-        #   org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-        #   org.opencontainers.image.revision=${{ github.sha }}
-        #   org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
 
         outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Inspect Docker image
+      run: |
+        docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.metadata.outputs.version }}
 
     - name: Export digest
       run: |
@@ -111,10 +110,10 @@ jobs:
       matrix:
         include:
         - base: debian
-          image: ghcr.io/${{ github.repository }}
+          image: ${{ env.REGISTRY }}/${{ github.repository }}
 
         - base: alpine
-          image: ghcr.io/${{ github.repository }}-alpine
+          image: ${{ env.REGISTRY }}/${{ github.repository }}-alpine
 
 
     runs-on: ubuntu-latest
@@ -131,8 +130,7 @@ jobs:
         pattern: digests-${{ matrix.base }}-*
         merge-multiple: true
 
-    - name: Set up Docker buildx
-      uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@v3
 
     - name: Collect Docker metadata
       id: metadata
@@ -140,18 +138,18 @@ jobs:
       with:
         images: ${{ matrix.image }}
 
-    # We need to authenticate with GHCR to push
-    - name: Authenticate with GitHub Container Registry
+    - name: Authenticate with Docker registry
       uses: docker/login-action@v3
       with:
-        registry: ghcr.io
+        registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Create manifest list and push
+    - name: Create and push merged image
       working-directory: /tmp/digests
       run: |
         docker buildx imagetools create \
+          $(jq -cr '.annotations | map("--annotation \"manifest-descriptor:" + (. | sub("^manifest:"; "")) + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf '${{ matrix.image }}@sha256:%s ' *)
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,31 +11,31 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: debian
+        - base: debian
           platform: linux/amd64
           dockerfile: Dockerfile
           image: ghcr.io/${{ github.repository }}
           runs-on: ubuntu-22.04
 
-        - name: debian
+        - base: debian
           platform: linux/arm64
           dockerfile: Dockerfile
           image: ghcr.io/${{ github.repository }}
           runs-on: ubuntu-22.04-arm64-8-core
 
-        - name: alpine
+        - base: alpine
           platform: linux/amd64
           dockerfile: Dockerfile.alpine
           image: ghcr.io/${{ github.repository }}-alpine
           runs-on: ubuntu-22.04
 
-        - name: alpine
+        - base: alpine
           platform: linux/arm64
           dockerfile: Dockerfile.alpine
           image: ghcr.io/${{ github.repository }}-alpine
           runs-on: ubuntu-22.04-arm64-8-core
 
-    name: Docker (${{ matrix.platform }} ${{ matrix.name }})
+    name: Docker (${{ matrix.platform }} ${{ matrix.base }})
     runs-on: ${{ matrix.runs-on }}
 
     steps:
@@ -72,17 +72,18 @@ jobs:
 
         context: .
 
-        platforms: ${{ matrix.platform }}
-
         file: ${{ matrix.dockerfile }}
 
-        labels: |
-          org.opencontainers.image.title=${{ github.event.repository.name }}
-          org.opencontainers.image.description=${{ github.event.repository.description }}
-          org.opencontainers.image.url=${{ github.event.repository.html_url }}
-          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+        platforms: ${{ matrix.platform }}
+
+        labels: ${{ steps.meta.outputs.labels }}
+        # labels: |
+        #   org.opencontainers.image.title=${{ github.event.repository.name }}
+        #   org.opencontainers.image.description=${{ github.event.repository.description }}
+        #   org.opencontainers.image.url=${{ github.event.repository.html_url }}
+        #   org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+        #   org.opencontainers.image.revision=${{ github.sha }}
+        #   org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
 
         outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
 
@@ -95,7 +96,7 @@ jobs:
     - name: Upload digest
       uses: actions/upload-artifact@v4
       with:
-        name: digests-${{ env.PLATFORM_PAIR }}
+        name: digests-${{ matrix.base }}-${{ env.PLATFORM_PAIR }}
         path: /tmp/digests/*
         if-no-files-found: error
         retention-days: 1
@@ -105,10 +106,10 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: debian
+        - base: debian
           image: ghcr.io/${{ github.repository }}
 
-        - name: alpine
+        - base: alpine
           image: ghcr.io/${{ github.repository }}-alpine
 
 
@@ -116,14 +117,14 @@ jobs:
     needs:
       - build
 
-    name: Docker (${{ matrix.name }})
+    name: Docker (${{ matrix.base }})
 
     steps:
     - name: Download digests
       uses: actions/download-artifact@v4
       with:
         path: /tmp/digests
-        pattern: digests-*
+        pattern: digests-${{ matrix.base }}-*
         merge-multiple: true
 
     - name: Set up Docker buildx

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,8 +57,15 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Docker metadata
+      id: metadata
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ matrix.image }}
+
     - name: Build and push by digest
       uses: docker/build-push-action@v6
+      id: build
       with:
         cache-from: type=gha,scope=${{ matrix.dockerfile }}
         cache-to: type=gha,scope=${{ matrix.dockerfile }},mode=min
@@ -119,11 +126,11 @@ jobs:
         pattern: digests-*
         merge-multiple: true
 
-    - name: Set up Docker Buildx
+    - name: Set up Docker buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Docker meta
-      id: meta
+    - name: Docker metadata
+      id: metadata
       uses: docker/metadata-action@v5
       with:
         images: ${{ matrix.image }}
@@ -136,10 +143,10 @@ jobs:
 
     - name: Inspect image
       run: |
-        docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.meta.outputs.version }}
+        docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.metadata.outputs.version }}
 
     - name: Test the Docker image
-      run: docker run --rm "${{ matrix.image }}:${{ steps.meta.outputs.version }}" --version
+      run: docker run --rm "${{ matrix.image }}:${{ steps.metadata.outputs.version }}" --version
 
     # We need to authenticate with GHCR both to push the tagged image for the
     # `main` branch

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -156,7 +156,7 @@ jobs:
       working-directory: /tmp/digests
       run: |
         xargs -0 docker buildx imagetools create \
-          "$DOCKER_METADATA_OUTPUT_TAGS" \
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf '${{ matrix.image }}@sha256:%s ' *)
 
     - name: Inspect Docker image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,24 +27,28 @@ jobs:
         include:
         - base: debian
           platform: linux/amd64
+          platform-pair: linux-amd64
           dockerfile: Dockerfile
           image: ghcr.io/${{ github.repository }}
           runs-on: ubuntu-22.04
 
         - base: debian
           platform: linux/arm64
+          platform-pair: linux-arm64
           dockerfile: Dockerfile
           image: ghcr.io/${{ github.repository }}
           runs-on: ubuntu-22.04-arm64-8-core
 
         - base: alpine
           platform: linux/amd64
+          platform-pair: linux-amd64
           dockerfile: Dockerfile.alpine
           image: ghcr.io/${{ github.repository }}-alpine
           runs-on: ubuntu-22.04
 
         - base: alpine
           platform: linux/arm64
+          platform-pair: linux-arm64
           dockerfile: Dockerfile.alpine
           image: ghcr.io/${{ github.repository }}-alpine
           runs-on: ubuntu-22.04-arm64-8-core
@@ -56,12 +60,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: docker/setup-buildx-action@v3
-
-    - name: Prepare
-      run: |
-        platform=${{ matrix.platform }}
-        # replace slashes in platform with dashes
-        echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
     - name: Authenticate with Docker registry
       uses: docker/login-action@v3
@@ -108,7 +106,7 @@ jobs:
     - name: Upload digest
       uses: actions/upload-artifact@v4
       with:
-        name: digests-${{ matrix.base }}-${{ env.PLATFORM_PAIR }}
+        name: digests-${{ matrix.base }}-${{ matrix.platform-pair }}
         path: /tmp/digests/*
         if-no-files-found: error
         retention-days: 1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -2,11 +2,7 @@ name: Release Artifacts
 
 on:
   push:
-    # The multiplatform Docker image is expensive to build (3h), so we are not
-    # currently running it for every commit to `main`.
-    # See #39 for more context.
-    #
-    # branches: [ "main" ]
+    branches: [ "main" ]
 
     # Run when release tags are created
     tags: [ "v*.*.*" ]
@@ -16,96 +12,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker:
-    strategy:
-      matrix:
-        include:
-        - build: debian
-          dockerfile: Dockerfile
-          image: ghcr.io/${{ github.repository }}
-
-        - build: alpine
-          dockerfile: Dockerfile.alpine
-          image: ghcr.io/${{ github.repository }}-alpine
-
-    name: Docker
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - uses: docker/setup-qemu-action@v3  # for multi-platform build
-
-    - uses: docker/setup-buildx-action@v3
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install zsh
-
-    - name: Authenticate with GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Docker metadata
-      id: docker_metadata
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ matrix.image }}
-
-        # see https://github.com/docker/metadata-action#tags-input
-        tags: |
-          type=semver,pattern={{raw}}
-          type=ref,event=tag
-          type=ref,event=pr
-          type=ref,event=branch
-
-    - name: Build linux/amd64 Docker image
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: ${{ matrix.dockerfile }}
-        platforms: linux/amd64
-        push: false
-        load: true
-        pull: true
-
-        tags: noseyparker:test
-        labels: |
-          ${{ steps.docker_metadata.outputs.labels }}
-          org.opencontainers.image.title=${{ github.event.repository.name }}
-          org.opencontainers.image.description=${{ github.event.repository.description }}
-          org.opencontainers.image.url=${{ github.event.repository.html_url }}
-          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-
-    - name: Test the Docker image
-      run: docker run --rm noseyparker:test --version
-
-    # This shouldn't end up building linux/amd64 again; it should get it from the local Docker cache
-    - name: Build multiplatform Docker image
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: ${{ matrix.dockerfile }}
-        platforms: linux/amd64,linux/arm64
-        push: true
-        pull: true
-
-        tags: ${{ steps.docker_metadata.outputs.tags }}
-        labels: |
-          ${{ steps.docker_metadata.outputs.labels }}
-          org.opencontainers.image.title=${{ github.event.repository.name }}
-          org.opencontainers.image.description=${{ github.event.repository.description }}
-          org.opencontainers.image.url=${{ github.event.repository.html_url }}
-          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-
-
   native:
     name: ${{ matrix.build }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This overhauls how the Docker images get built in GitHub Actions.

Previously, only x86_64 Docker images were being built for non-release commits, as using QEMU to build multiplatform images for arm64 as well takes a very long time.

Now, with these changes, the GitHub Actions workflow that builds the Docker images builds for x86_64 and arm64 as separate jobs on native CPU runners, and then merges the individual images together.

This was adapted from the example on the [Docker documentation site](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners).

Fixes #156.
Fixes #91.