### PR TITLE
Rework parallelism in enumeration and scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,6 +2530,7 @@ dependencies = [
  "assert_fs",
  "base64",
  "bstr",
+ "bstring-serde",
  "clap",
  "clap_complete",
  "clap_mangen",

--- a/crates/input-enumerator/src/git_repo_enumerator.rs
+++ b/crates/input-enumerator/src/git_repo_enumerator.rs
@@ -88,6 +88,9 @@ pub struct GitRepoResult {
     /// Path to the repository clone
     pub path: PathBuf,
 
+    /// The opened Git repository
+    pub repository: Repository,
+
     /// The blobs to be scanned
     pub blobs: Vec<BlobMetadata>,
 
@@ -119,12 +122,12 @@ pub struct BlobMetadata {
 // -------------------------------------------------------------------------------------------------
 pub struct GitRepoWithMetadataEnumerator<'a> {
     path: &'a Path,
-    repo: &'a Repository,
+    repo: Repository,
     gitignore: &'a Gitignore,
 }
 
 impl<'a> GitRepoWithMetadataEnumerator<'a> {
-    pub fn new(path: &'a Path, repo: &'a Repository, gitignore: &'a Gitignore) -> Self {
+    pub fn new(path: &'a Path, repo: Repository, gitignore: &'a Gitignore) -> Self {
         Self {
             path,
             repo,
@@ -132,7 +135,7 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
         }
     }
 
-    pub fn run(&self) -> Result<GitRepoResult> {
+    pub fn run(self) -> Result<GitRepoResult> {
         let t1 = Instant::now();
 
         use gix::object::Kind;
@@ -254,6 +257,7 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
                     })
                     .collect();
                 Ok(GitRepoResult {
+                    repository: self.repo,
                     path,
                     blobs,
                     commit_metadata,
@@ -348,6 +352,7 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
                     .collect();
 
                 Ok(GitRepoResult {
+                    repository: self.repo,
                     path,
                     blobs,
                     commit_metadata,
@@ -362,15 +367,15 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
 // -------------------------------------------------------------------------------------------------
 pub struct GitRepoEnumerator<'a> {
     path: &'a Path,
-    repo: &'a Repository,
+    repo: Repository,
 }
 
 impl<'a> GitRepoEnumerator<'a> {
-    pub fn new(path: &'a Path, repo: &'a Repository) -> Self {
+    pub fn new(path: &'a Path, repo: Repository) -> Self {
         Self { path, repo }
     }
 
-    pub fn run(&self) -> Result<GitRepoResult> {
+    pub fn run(self) -> Result<GitRepoResult> {
         use gix::object::Kind;
         use gix::odb::store::iter::Ordering;
         use gix::prelude::*;
@@ -406,6 +411,7 @@ impl<'a> GitRepoEnumerator<'a> {
             })
             .collect();
         Ok(GitRepoResult {
+            repository: self.repo,
             path,
             blobs,
             commit_metadata: Default::default(),

--- a/crates/noseyparker-cli/Cargo.toml
+++ b/crates/noseyparker-cli/Cargo.toml
@@ -64,6 +64,7 @@ vergen = { version = "8.3", features = ["build", "cargo", "git", "gitcl", "rustc
 
 [dependencies]
 anyhow = { version = "1.0" }
+bstring-serde = { path = "../bstring-serde" }
 bstr = { version = "1.0" }
 clap = { version = "4.3", features = ["cargo", "derive", "env", "unicode", "wrap_help"] }
 clap_complete = "4.4"

--- a/crates/noseyparker-cli/tests/scan/with_ignore/mod.rs
+++ b/crates/noseyparker-cli/tests/scan/with_ignore/mod.rs
@@ -11,8 +11,8 @@ fn root_input_noignore_01() {
     let ignore_file = scan_env.input_file_with_contents(
         "npignore",
         indoc! {r#"
-        input.dat
-    "#},
+            input.dat
+        "#},
     );
 
     let input = scan_env.input_file_with_secret("input.dat");
@@ -37,8 +37,8 @@ fn root_input_noignore_02() {
     let ignore_file = scan_env.input_file_with_contents(
         "npignore",
         indoc! {r#"
-        input
-    "#},
+            input
+        "#},
     );
 
     let input = scan_env.input_dir("input");
@@ -61,8 +61,8 @@ fn literal_match_01() {
     let ignore_file = scan_env.input_file_with_contents(
         "npignore",
         indoc! {r#"
-        input.dat
-    "#},
+            input.dat
+        "#},
     );
 
     let input = scan_env.input_dir("input");
@@ -78,8 +78,8 @@ fn literal_match_02() {
     let ignore_file = scan_env.input_file_with_contents(
         "npignore",
         indoc! {r#"
-        whoohaw/input.dat
-    "#},
+            whoohaw/input.dat
+        "#},
     );
 
     let input = scan_env.input_dir("input");
@@ -102,8 +102,8 @@ fn literal_match_03() {
     let ignore_file = scan_env.input_file_with_contents(
         "npignore",
         indoc! {r#"
-        subdir1/
-    "#},
+            subdir1/
+        "#},
     );
 
     let input = scan_env.input_dir("input");
@@ -126,10 +126,13 @@ fn glob_01() {
     let ignore_file = scan_env.input_file_with_contents(
         "npignore",
         indoc! {r#"
-        # here is a comment
-        *.dat
-    "#},
+            # here is a comment
+            *.dat
+        "#},
     );
+    assert!(ignore_file.is_file());
+    let contents = std::fs::read_to_string(ignore_file.path()).unwrap();
+    println!("ignore file at {}:\n#####\n{}\n#####", ignore_file.display(), contents);
 
     let input = scan_env.input_dir("input");
     scan_env.input_file_with_secret("input/input.dat");
@@ -153,8 +156,8 @@ fn path_glob_01() {
     let ignore_file = scan_env.input_file_with_contents(
         "npignore",
         indoc! {r#"
-        **/test
-    "#},
+            **/test
+        "#},
     );
 
     let input = scan_env.input_dir("input");
@@ -179,9 +182,9 @@ fn negation_01() {
     let ignore_file = scan_env.input_file_with_contents(
         "npignore",
         indoc! {r#"
-        *.dat
-        !**/subdir1/**
-    "#},
+            *.dat
+            !**/subdir1/**
+        "#},
     );
 
     let input = scan_env.input_dir("input");


### PR DESCRIPTION
- The `FilesystemEnumerator` type now _only_ enumerates directories and files, and as such is a relatively lightweight task.

- Heavyweight enumeration tasks, including walking through Git history and extensible enumerator output (i.e., from the `--enumerator=FILE` option) are now performed by scanner threads instead of filesystem enumerator threads.

- Git repositories are now opened just a single time instead of twice.

- A new `ParallelBlobIterator` trait codifies things that can be enumerated to produce blobs with provenance metadata. This includes for now Git repositories, regular files, extensible enumerators. This starts to put in place necessary pieces to allow for enumeration of tarfiles, compressed archives, etc.

- Large parts of the `scan` command logic are now extracted into functions.

- The overall parallelism approach is a bit easier to see now: parallel filesystem input enumeration ==channel==> parallel scanning ==channel==> sequential datastore persistence.