### PR TITLE
Reduce memory and CPU use when scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changes
 - Inputs are now enumerated incrementally as scanning proceeds rather than done in an initial batch step ([#216](https://github.com/praetorian-inc/noseyparker/pull/216)).
-  This reduces peak memory use and CPU time 10-20%, particularly in environments with slow I/O.
+  This reduces peak memory use and wall clock time 10-20%, particularly in environments with slow I/O.
   A consequence of this change is that the total amount of data to scan is not known until it has actually been scanned, and so the scanning progress bar no longer shows a completion percentage.
 
 - When cloning Git repositories while scanning, the progress bar for now includes the current repository URL ([#212](https://github.com/praetorian-inc/noseyparker/pull/212)).
@@ -38,17 +38,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   - Bitbucket App Password ([#219](https://github.com/praetorian-inc/noseyparker/pull/219) from @gemesa)
 
-- The default number of parallel scanning jobs, which is determined in part by system RAM capacity, has been increased slightly in response to several improvements in memory use during scanning.
+- The default number of parallel scanner jobs is now higher on many systems ([#222](https://github.com/praetorian-inc/noseyparker/pull/222)).
+  This value is determined in part by the amount of system RAM;
+  due to several memory use improvements, the required minim RAM per job has been reduced, allowing for more parallelism.
 
 ### Fixes
-
 - The `Google OAuth Credentials` rule has been revised to avoid runtime errors about an empty capture group.
 
 - The `AWS Secret Access Key` rule has been revised to avoid runtime `Regex failed to match` errors.
 
-- The code that determines first-commit provenance information for blobs from Git repositories has been reworked to improve memory use.
-  In typical cases of scanning Git repositories, this reduces both peak memory use and CPU use by 20-50%.
-  In certain pathological cases, such as [Homebrew](https://github.com/homebrew/homebrew-core) or [nixpkgs](https://github.com/NixOS/nixpkgs), the new implementation uses 10-20x less peak memory and 3-6x less CPU.
+- The code that determines first-commit provenance information for blobs from Git repositories has been reworked to improve memory use ([#222](https://github.com/praetorian-inc/noseyparker/pull/222)).
+  In typical cases of scanning Git repositories, this reduces both peak memory use and wall clock time by 20-50%.
+  In certain pathological cases, such as [Homebrew](https://github.com/homebrew/homebrew-core) or [nixpkgs](https://github.com/NixOS/nixpkgs), the new implementation uses up to 20x less peak memory and up to 5x less wall clock time.
+
+- When determining blob provenance informatino from Git repositories, blobs that first appear multiple times within a single commit will now be reported with _all_ names they appear with ([#222](https://github.com/praetorian-inc/noseyparker/pull/222)).
+  Previously, one of the pathnames would be arbitrarily selected.
 
 
 ## [v0.19.0](https://github.com/praetorian-inc/noseyparker/releases/v0.19.0) (2024-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   - Bitbucket App Password ([#219](https://github.com/praetorian-inc/noseyparker/pull/219) from @gemesa)
 
+- The default number of parallel scanning jobs, which is determined in part by system RAM capacity, has been increased slightly in response to several improvements in memory use during scanning.
+
 ### Fixes
 
 - The `Google OAuth Credentials` rule has been revised to avoid runtime errors about an empty capture group.
+
 - The `AWS Secret Access Key` rule has been revised to avoid runtime `Regex failed to match` errors.
+
+- The code that determines first-commit provenance information for blobs from Git repositories has been reworked to improve memory use.
+  In typical cases of scanning Git repositories, this reduces both peak memory use and CPU use by 20-50%.
+  In certain pathological cases, such as [Homebrew](https://github.com/homebrew/homebrew-core) or [nixpkgs](https://github.com/NixOS/nixpkgs), the new implementation uses 10-20x less peak memory and 3-6x less CPU.
 
 
 ## [v0.19.0](https://github.com/praetorian-inc/noseyparker/releases/v0.19.0) (2024-07-30)

--- a/crates/input-enumerator/src/blob_appearance.rs
+++ b/crates/input-enumerator/src/blob_appearance.rs
@@ -1,13 +1,13 @@
+use crate::git_commit_metadata::CommitMetadata;
 use bstr::{BString, ByteSlice};
-use gix::ObjectId;
 use smallvec::SmallVec;
 use std::path::Path;
+use std::sync::Arc;
 
 /// Where was a particular blob seen?
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct BlobAppearance {
-    /// The commit ID
-    pub commit_oid: ObjectId,
+    pub commit_metadata: Arc<CommitMetadata>,
 
     /// The path given to the blob
     pub path: BString,
@@ -21,4 +21,4 @@ impl BlobAppearance {
 }
 
 /// A set of `BlobAppearance` entries
-pub type BlobAppearanceSet = SmallVec<[BlobAppearance; 1]>;
+pub type BlobAppearanceSet = SmallVec<[BlobAppearance; 2]>;

--- a/crates/input-enumerator/src/bstring_table.rs
+++ b/crates/input-enumerator/src/bstring_table.rs
@@ -10,6 +10,10 @@ pub struct Symbol<T> {
 pub trait SymbolType: Copy + PartialEq + Eq + std::hash::Hash {
     fn to_range(self) -> std::ops::Range<usize>;
     fn from_range(r: std::ops::Range<usize>) -> Self;
+
+    fn len(&self) -> usize {
+        self.to_range().len()
+    }
 }
 
 impl SymbolType for Symbol<usize> {

--- a/crates/input-enumerator/src/bstring_table.rs
+++ b/crates/input-enumerator/src/bstring_table.rs
@@ -7,6 +7,7 @@ pub struct Symbol<T> {
     j: T,
 }
 
+#[allow(clippy::len_without_is_empty)]
 pub trait SymbolType: Copy + PartialEq + Eq + std::hash::Hash {
     fn to_range(self) -> std::ops::Range<usize>;
     fn from_range(r: std::ops::Range<usize>) -> Self;

--- a/crates/input-enumerator/src/git_metadata_graph.rs
+++ b/crates/input-enumerator/src/git_metadata_graph.rs
@@ -438,12 +438,8 @@ impl GitMetadataGraph {
         }
 
         // A worklist of tree objects (and no other type) to be traversed
-        const INITIAL_TREE_WORKLIST_CAPACITY: usize = 32 * 1024;
-        let mut tree_worklist = TreeWorklist::with_capacity(INITIAL_TREE_WORKLIST_CAPACITY);
-        let mut warned_tree_worklist = false;
-        const INITAL_TREE_BUF_CAPACITY: usize = 1024 * 1024;
-        let mut tree_buf = Vec::with_capacity(INITAL_TREE_BUF_CAPACITY);
-        let mut warned_tree_buf = false;
+        let mut tree_worklist = TreeWorklist::with_capacity(32 * 1024);
+        let mut tree_buf = Vec::with_capacity(1024 * 1024);
 
         // various counters for statistics
         let mut max_frontier_size = 0; // max value of size of `commit_worklist`
@@ -495,20 +491,6 @@ impl GitMetadataGraph {
                         &mut tree_buf,
                         &mut tree_worklist,
                     )?;
-
-                    if !warned_tree_buf && tree_buf.capacity() != INITAL_TREE_BUF_CAPACITY {
-                        warn!("tree buf capacity had to be resized to {}", tree_buf.capacity());
-                        warned_tree_buf = true;
-                    }
-                    if !warned_tree_worklist
-                        && tree_worklist.capacity() != INITIAL_TREE_WORKLIST_CAPACITY
-                    {
-                        warn!(
-                            "tree worklist capacity had to be resized to {}",
-                            tree_worklist.capacity()
-                        );
-                        warned_tree_worklist = true;
-                    }
                 }
             } else {
                 warn!(

--- a/crates/input-enumerator/src/git_metadata_graph.rs
+++ b/crates/input-enumerator/src/git_metadata_graph.rs
@@ -461,7 +461,7 @@ impl GitMetadataGraph {
                 continue;
             }
 
-            let mut introduced = &mut blobs_introduced[commit_index];
+            let introduced = &mut blobs_introduced[commit_index];
 
             let mut seen = seen_sets[commit_index]
                 .take()
@@ -487,11 +487,11 @@ impl GitMetadataGraph {
                     visit_tree(
                         repo,
                         &mut symbols,
-                        &repo_index,
+                        repo_index,
                         &mut num_trees_introduced,
                         &mut num_blobs_introduced,
                         &mut seen,
-                        &mut introduced,
+                        introduced,
                         &mut tree_buf,
                         &mut tree_worklist,
                     )?;
@@ -589,6 +589,7 @@ impl GitMetadataGraph {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn visit_tree(
     repo: &gix::Repository,
     symbols: &mut BStringTable,
@@ -608,7 +609,7 @@ fn visit_tree(
             |e| error!("Failed to find tree {tree_oid}: {e}"),
         );
 
-        *num_trees_introduced = *num_trees_introduced + 1;
+        *num_trees_introduced += 1;
 
         for child in tree_iter {
             let child = unwrap_ok_or_continue!(child, |e| {
@@ -642,7 +643,7 @@ fn visit_tree(
                         continue;
                     }
 
-                    *num_blobs_introduced = *num_blobs_introduced + 1;
+                    *num_blobs_introduced += 1;
 
                     // Compute full path to blob as a bytestring.
                     // Instead of using `bstr::join`, manually construct the string to

--- a/crates/input-enumerator/src/git_repo_enumerator.rs
+++ b/crates/input-enumerator/src/git_repo_enumerator.rs
@@ -10,7 +10,7 @@ use tracing::{debug, debug_span, error};
 
 use crate::blob_appearance::{BlobAppearance, BlobAppearanceSet};
 use crate::git_commit_metadata::CommitMetadata;
-use crate::git_metadata_graph::{GitMetadataGraph, ObjectIndex};
+use crate::git_metadata_graph::{GitMetadataGraph, RepositoryIndex};
 use crate::{unwrap_ok_or_continue, unwrap_some_or_continue};
 
 // -------------------------------------------------------------------------------------------------
@@ -25,11 +25,6 @@ pub struct GitRepoResult {
 
     /// The blobs to be scanned
     pub blobs: Vec<BlobMetadata>,
-
-    /// Finite map from commit ID to metadata
-    ///
-    /// NOTE: this may be incomplete, missing entries for some commits
-    pub commit_metadata: HashMap<ObjectId, Arc<CommitMetadata>>,
 }
 
 #[derive(Clone)]
@@ -59,7 +54,6 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
     pub fn run(self) -> Result<GitRepoResult> {
         let t1 = Instant::now();
 
-        use gix::object::Kind;
         use gix::prelude::*;
 
         let _span = debug_span!("enumerate_git_with_metadata", "{}", self.path.display()).entered();
@@ -69,7 +63,7 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
         // First count the objects to figure out how big to allocate data structures.
         // We're assuming that the repository doesn't change in the meantime.
         // If it does, our allocation estimates won't be right. Too bad!
-        let object_index = ObjectIndex::new(odb)?;
+        let object_index = RepositoryIndex::new(odb)?;
         debug!(
             "Indexed {} objects in {:.6}s; {} blobs; {} commits",
             object_index.num_objects(),
@@ -78,7 +72,6 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
             object_index.num_commits(),
         );
 
-        let mut blobs: Vec<ObjectId> = Vec::with_capacity(object_index.num_blobs());
         let mut metadata_graph = GitMetadataGraph::with_capacity(object_index.num_commits());
 
         // scratch buffer used for decoding commits.
@@ -89,45 +82,34 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
         let mut commit_metadata =
             HashMap::with_capacity_and_hasher(object_index.num_commits(), Default::default());
 
-        for &(oid, kind) in object_index.idx_to_oid_and_md.iter() {
-            match kind {
-                Kind::Blob => blobs.push(oid),
+        for commit_oid in object_index.commits() {
+            let commit = unwrap_ok_or_continue!(odb.find_commit(commit_oid, &mut scratch), |e| {
+                error!("Failed to find commit {commit_oid}: {e}");
+            });
 
-                Kind::Commit => {
-                    let commit = unwrap_ok_or_continue!(odb.find_commit(&oid, &mut scratch), |e| {
-                        error!("Failed to find commit {oid}: {e}");
-                    });
-
-                    let tree_oid = commit.tree();
-                    let tree_idx =
-                        unwrap_some_or_continue!(object_index.get_index(&tree_oid), || {
-                            error!("Failed to find tree {tree_oid} for commit {oid}");
-                        });
-                    let commit_idx = metadata_graph.get_commit_idx(oid, Some(tree_idx));
-                    for parent_oid in commit.parents() {
-                        let parent_idx = metadata_graph.get_commit_idx(parent_oid, None);
-                        metadata_graph.add_commit_edge(parent_idx, commit_idx);
-                    }
-
-                    let committer = &commit.committer;
-                    let author = &commit.author;
-                    let md = CommitMetadata {
-                        commit_id: oid,
-                        committer_name: committer.name.to_owned(),
-                        committer_timestamp: committer.time,
-                        committer_email: committer.email.to_owned(),
-                        author_name: author.name.to_owned(),
-                        author_timestamp: author.time,
-                        author_email: author.email.to_owned(),
-                        message: commit.message.to_owned(),
-                    };
-                    commit_metadata.insert(oid, Arc::new(md));
-                }
-
-                Kind::Tree => {}
-
-                Kind::Tag => {}
+            let tree_oid = commit.tree();
+            let tree_idx = unwrap_some_or_continue!(object_index.get_tree_index(&tree_oid), || {
+                error!("Failed to find tree {tree_oid} for commit {commit_oid}");
+            });
+            let commit_idx = metadata_graph.get_commit_idx(*commit_oid, Some(tree_idx));
+            for parent_oid in commit.parents() {
+                let parent_idx = metadata_graph.get_commit_idx(parent_oid, None);
+                metadata_graph.add_commit_edge(parent_idx, commit_idx);
             }
+
+            let committer = &commit.committer;
+            let author = &commit.author;
+            let md = CommitMetadata {
+                commit_id: *commit_oid,
+                committer_name: committer.name.to_owned(),
+                committer_timestamp: committer.time,
+                committer_email: committer.email.to_owned(),
+                author_name: author.name.to_owned(),
+                author_timestamp: author.time,
+                author_email: author.email.to_owned(),
+                message: commit.message.to_owned(),
+            };
+            commit_metadata.insert(*commit_oid, Arc::new(md));
         }
 
         debug!("Built metadata graph in {:.6}s", t1.elapsed().as_secs_f64());
@@ -135,7 +117,8 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
         match metadata_graph.get_repo_metadata(&object_index, &self.repo) {
             Err(e) => {
                 error!("Failed to compute reachable blobs; ignoring metadata: {e}");
-                let blobs = blobs
+                let blobs = object_index
+                    .into_blobs()
                     .into_iter()
                     .map(|blob_oid| BlobMetadata {
                         blob_oid,
@@ -146,22 +129,26 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
                     repository: self.repo,
                     path: self.path.to_owned(),
                     blobs,
-                    commit_metadata,
                 })
             }
             Ok(md) => {
-                let mut blob_to_appearance =
-                    HashMap::<ObjectId, SmallVec<[BlobAppearance; 1]>>::with_capacity_and_hasher(
-                        object_index.num_blobs(),
-                        Default::default(),
-                    );
+                let mut blob_to_appearance: HashMap<ObjectId, BlobAppearanceSet> = object_index
+                    .into_blobs()
+                    .into_iter()
+                    .map(|b| (b, SmallVec::new()))
+                    .collect();
+
                 for e in md.into_iter() {
+                    let commit_metadata =
+                        unwrap_some_or_continue!(commit_metadata.get(&e.commit_oid), || {
+                            error!("Failed to find commit metadata for {}", e.commit_oid);
+                        });
                     for (blob_oid, path) in e.introduced_blobs.into_iter() {
                         let vals = blob_to_appearance
                             .entry(blob_oid)
                             .or_insert(SmallVec::new());
                         vals.push(BlobAppearance {
-                            commit_oid: e.commit_oid,
+                            commit_metadata: commit_metadata.clone(),
                             path,
                         });
                     }
@@ -183,26 +170,20 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
                 //
                 // It's also possible (though rare) that a blob appears in a Git repository with
                 // _no_ path whatsoever.
-                //
-                // Anyway, when Nosey Parker is determining whether a blob should be gitignored or
-                // not, the logic is this:
-                //
-                // - If the set of pathnames for a blob is empty, *do not* ignore the blob.
-                //
-                // - If the set of pathnames for a blob is *not* empty, if *all* of the pathnames
-                //   match the gitignore rules, ignore the blob.
-
-                let blobs: Vec<_> = blobs
+                let blobs: Vec<BlobMetadata> = blob_to_appearance
                     .into_iter()
-                    .filter_map(|blob_oid| match blob_to_appearance.get(&blob_oid) {
-                        None => Some(BlobMetadata {
-                            blob_oid,
-                            first_seen: SmallVec::new(),
-                        }),
-
-                        Some(first_seen) => {
-                            let first_seen: SmallVec<_> = first_seen
-                                .iter()
+                    .filter_map(|(blob_oid, first_seen)| {
+                        if first_seen.is_empty() {
+                            // no commit metadata at all for blob
+                            Some(BlobMetadata {
+                                blob_oid,
+                                first_seen,
+                            })
+                        } else {
+                            // filter out path-ignored provenance entries; suppress blob if all
+                            // provenance entries get filtered
+                            let first_seen: BlobAppearanceSet = first_seen
+                                .into_iter()
                                 .filter(|entry| {
                                     use bstr::ByteSlice;
                                     match entry.path.to_path() {
@@ -221,7 +202,6 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
                                         }
                                     }
                                 })
-                                .cloned()
                                 .collect();
 
                             if first_seen.is_empty() {
@@ -241,7 +221,6 @@ impl<'a> GitRepoWithMetadataEnumerator<'a> {
                     repository: self.repo,
                     path: self.path.to_owned(),
                     blobs,
-                    commit_metadata,
                 })
             }
         }
@@ -297,7 +276,6 @@ impl<'a> GitRepoEnumerator<'a> {
             repository: self.repo,
             path: self.path.to_owned(),
             blobs,
-            commit_metadata: Default::default(),
         })
     }
 }

--- a/crates/input-enumerator/src/lib.rs
+++ b/crates/input-enumerator/src/lib.rs
@@ -11,6 +11,40 @@ use ignore::{DirEntry, WalkBuilder, WalkState};
 use std::path::{Path, PathBuf};
 use tracing::{debug, error, warn};
 
+// -------------------------------------------------------------------------------------------------
+// helper macros
+// -------------------------------------------------------------------------------------------------
+macro_rules! unwrap_some_or_continue {
+    ($arg:expr, $on_error:expr $(,)?) => {
+        match $arg {
+            Some(v) => v,
+            None => {
+                #[allow(clippy::redundant_closure_call)]
+                $on_error();
+                continue;
+            }
+        }
+    };
+}
+
+pub(crate) use unwrap_some_or_continue;
+
+macro_rules! unwrap_ok_or_continue {
+    ($arg:expr, $on_error:expr $(,)?) => {
+        match $arg {
+            Ok(v) => v,
+            Err(e) => {
+                #[allow(clippy::redundant_closure_call)]
+                $on_error(e);
+                continue;
+            }
+        }
+    };
+}
+
+pub(crate) use unwrap_ok_or_continue;
+
+// -------------------------------------------------------------------------------------------------
 mod git_repo_enumerator;
 pub use git_repo_enumerator::{GitRepoEnumerator, GitRepoResult, GitRepoWithMetadataEnumerator};
 

--- a/crates/noseyparker-cli/src/args.rs
+++ b/crates/noseyparker-cli/src/args.rs
@@ -104,7 +104,7 @@ fn default_scan_jobs() -> usize {
     match (std::thread::available_parallelism(), *RAM_GB) {
         (Ok(v), Some(ram_gb)) => {
             let n: usize = v.into();
-            let max_n = (ram_gb / 4.0).ceil().max(1.0) as usize;
+            let max_n = (ram_gb / 3.0).ceil().max(1.0) as usize;
             n.clamp(1, max_n)
         }
         (Ok(v), None) => v.into(),

--- a/crates/noseyparker-cli/src/cmd_report/sarif_format.rs
+++ b/crates/noseyparker-cli/src/cmd_report/sarif_format.rs
@@ -143,7 +143,7 @@ fn noseyparker_sarif_rules() -> Result<Vec<sarif::ReportingDescriptor>> {
         .iter_rules()
         .map(|rule| {
             let help = sarif::MultiformatMessageStringBuilder::default()
-                .text(&rule.references.join("\n"))
+                .text(rule.references.join("\n"))
                 .build()?;
 
             // FIXME: add better descriptions to Nosey Parker rules

--- a/crates/noseyparker-cli/src/cmd_scan.rs
+++ b/crates/noseyparker-cli/src/cmd_scan.rs
@@ -101,7 +101,6 @@ impl ParallelIterator for EnumeratorFileIter {
         use std::io::BufRead;
         (1usize..)
             .zip(self.reader.lines())
-            .into_iter()
             .filter_map(|(line_num, line)| line.map(|line| (line_num, line)).ok())
             .par_bridge()
             .map(|(line_num, line)| {
@@ -371,7 +370,7 @@ pub fn run(global_args: &args::GlobalArgs, args: &args::ScanArgs) -> Result<()> 
     // ---------------------------------------------------------------------------------------------
     let repo_urls = {
         let mut repo_urls = args.input_specifier_args.git_url.clone();
-        repo_urls.extend(enumerate_github_repos(&global_args, &args)?);
+        repo_urls.extend(enumerate_github_repos(global_args, args)?);
         repo_urls.sort();
         repo_urls.dedup();
         repo_urls
@@ -383,7 +382,7 @@ pub fn run(global_args: &args::GlobalArgs, args: &args::ScanArgs) -> Result<()> 
     let input_roots = {
         let mut input_roots = args.input_specifier_args.path_inputs.clone();
         if !repo_urls.is_empty() {
-            input_roots.extend(clone_git_repo_urls(&global_args, &args, &datastore, repo_urls)?);
+            input_roots.extend(clone_git_repo_urls(global_args, args, &datastore, repo_urls)?);
         }
         input_roots.sort();
         input_roots.dedup();
@@ -480,7 +479,7 @@ pub fn run(global_args: &args::GlobalArgs, args: &args::ScanArgs) -> Result<()> 
         let guesser = Guesser::new().expect("should be able to create filetype guessser");
         {
             let mut init_time = blob_processor_init_time.lock().unwrap();
-            *init_time = *init_time + t1.elapsed();
+            *init_time += t1.elapsed();
         }
 
         BlobProcessor {

--- a/crates/noseyparker/Cargo.toml
+++ b/crates/noseyparker/Cargo.toml
@@ -49,7 +49,7 @@ rusqlite = { version = "0.32", features = ["bundled", "backup", "serde_json"] }
 schemars = { version = "0.8", features = ["smallvec"] }
 secrecy = { version = "0.8.0", optional = true }
 smallvec = { version = "1", features = ["const_generics", "const_new", "union"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0" }
 thiserror = "1"
 tokio = { version = "1.23", optional = true }

--- a/crates/noseyparker/src/provenance.rs
+++ b/crates/noseyparker/src/provenance.rs
@@ -4,6 +4,7 @@ use input_enumerator::git_commit_metadata::CommitMetadata;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 // -------------------------------------------------------------------------------------------------
 // Provenance
@@ -41,7 +42,7 @@ impl Provenance {
     /// See also `from_git_repo`.
     pub fn from_git_repo_with_first_commit(
         repo_path: PathBuf,
-        commit_metadata: CommitMetadata,
+        commit_metadata: Arc<CommitMetadata>,
         blob_path: BString,
     ) -> Self {
         let first_commit = Some(CommitProvenance {
@@ -119,7 +120,7 @@ pub struct GitRepoProvenance {
 /// How was a particular Git commit encountered?
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct CommitProvenance {
-    pub commit_metadata: CommitMetadata,
+    pub commit_metadata: Arc<CommitMetadata>,
 
     #[serde(with = "BStringLossyUtf8")]
     pub blob_path: BString,

--- a/crates/noseyparker/src/provenance.rs
+++ b/crates/noseyparker/src/provenance.rs
@@ -29,7 +29,7 @@ impl Provenance {
     /// commit provenance.
     ///
     /// See also `from_git_repo_with_first_commit`.
-    pub fn from_git_repo(repo_path: PathBuf) -> Self {
+    pub fn from_git_repo(repo_path: Arc<PathBuf>) -> Self {
         Provenance::GitRepo(GitRepoProvenance {
             repo_path,
             first_commit: None,
@@ -41,7 +41,7 @@ impl Provenance {
     ///
     /// See also `from_git_repo`.
     pub fn from_git_repo_with_first_commit(
-        repo_path: PathBuf,
+        repo_path: Arc<PathBuf>,
         commit_metadata: Arc<CommitMetadata>,
         blob_path: BString,
     ) -> Self {
@@ -110,7 +110,7 @@ pub struct FileProvenance {
 /// Indicates that a blob was seen in a Git repo, optionally with particular commit provenance info
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct GitRepoProvenance {
-    pub repo_path: PathBuf,
+    pub repo_path: Arc<PathBuf>,
     pub first_commit: Option<CommitProvenance>,
 }
 

--- a/crates/noseyparker/src/provenance_set.rs
+++ b/crates/noseyparker/src/provenance_set.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::ser::SerializeSeq;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::provenance::Provenance;
 
@@ -52,7 +53,7 @@ impl ProvenanceSet {
     /// Create a new `ProvenanceSet` from the given items, filtering out redundant less-specific
     /// `Provenance` records.
     pub fn new(provenance: Provenance, more_provenance: Vec<Provenance>) -> Self {
-        let mut git_repos_with_detailed: HashSet<PathBuf> = HashSet::new();
+        let mut git_repos_with_detailed: HashSet<Arc<PathBuf>> = HashSet::new();
 
         for p in std::iter::once(&provenance).chain(&more_provenance) {
             if let Provenance::GitRepo(e) = p {


### PR DESCRIPTION
Rework git metadata calculation to reduce peak memory and wall clock time when scanning. This includes many changes.  The net effect of all this is a typical 30% speedup and 50% memory reduction when scanning Git repositories; in pathological cases, up to 5x speedup and 20x memory reduction.

- Git metadata graph:
  - Do not construct in-memory graph of all trees and blob names; instead, read tree objects from repo as late as possible
  - Use `SmallVec` to reduce heap fragmentation and small heap allocations
  - Use more suitable initial size for worklists and scratch buffers to reduce reallocations and heap fragmentation
  - Use the fastest / slimmest order for iterating object headers from a git repository when initially counting objects
  - Eliminate redundant intermediate data structures; remove unused fields from remaining intermediate data structures
  - Avoid temporary allocations when concatenating blob filenames
  - Fix a longstanding bug where a blob introduced multiple times within a single commit would have only a single arbitrary pathname reported
 
- `BStringTable`:
  - change default initialization to create an empty table
  - change `get_or_intern` to avoid heap-allocated temporaries when an entry already exists

- Scanning:
  - Use an `Arc<CommitMetadata>` instead of `CommitMetadata` and `Arc<PathBuf>` instead of `PathBuf` within git blob provenance entries (allows sharing; sometimes reduces memory use of these object types 10,000x)
  - Use a higher default level of parallelism: require 3GiB RAM instead of 4GiB per parallel job
  - Open Git repositories a single time instead of twice