### PR TITLE
Add a release artifacts job for statically-linked Linux releases

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -100,10 +100,10 @@ jobs:
 
     - name: Inspect Docker image
       run: |
-        docker buildx imagetools inspect "${{ matrix.image }}:sha256@${{ steps.build.outputs.digest }}"
+        docker buildx imagetools inspect "${{ matrix.image }}@${{ steps.build.outputs.digest }}"
 
     - name: Test Docker image
-      run: docker run --rm "${{ matrix.image }}:sha256@${{ steps.build.outputs.digest }}" --version
+      run: docker run --rm "${{ matrix.image }}@${{ steps.build.outputs.digest }}" --version
 
     - name: Export digest
       run: |
@@ -165,7 +165,7 @@ jobs:
       run: |
         docker buildx imagetools create \
           $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-          $(printf '${{ matrix.image }}@sha256:%s ' *)
+          $(printf '${{ matrix.image }}@%s ' *)
 
     - name: Inspect Docker image
       run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -100,7 +100,7 @@ jobs:
 
     - name: Inspect Docker image
       run: |
-        docker buildx imagetools inspect ${{ matrix.image }}:sha256@${{ steps.build.outputs.digest }}
+        docker buildx imagetools inspect "${{ matrix.image }}:sha256@${{ steps.build.outputs.digest }}"
 
     - name: Test Docker image
       run: docker run --rm "${{ matrix.image }}:sha256@${{ steps.build.outputs.digest }}" --version

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -120,6 +120,8 @@ jobs:
 
         tags: noseyparker
 
+        target: builder
+
         outputs: type=image
 
     - name: Inspect Docker image
@@ -131,7 +133,8 @@ jobs:
 
     - name: Copy release build from Docker container
       run: |
-        docker cp $(docker run --name np "noseyparker@${{ steps.build.outputs.digest }}"):/usr/local release
+        docker run --name np "noseyparker@${{ steps.build.outputs.digest }}"
+        docker cp np:/release release
         docker rm np
 
     - name: Run integration tests on release

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -100,7 +100,7 @@ jobs:
           platform-pair: linux-arm64
           runs-on: ubuntu-22.04-arm64-8-core
 
-    name: Linux (${{ matrix.platform }} musl
+    name: ${{ matrix.platform }} musl
     runs-on: ${{ matrix.runs-on }}
 
     steps:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -118,10 +118,6 @@ jobs:
         load: true
         target: builder
 
-    - name: Inspect Docker image
-      run: |
-        docker buildx imagetools inspect noseyparker
-
     - name: Test Docker image
       run: docker run --rm noseyparker --version
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -108,6 +108,10 @@ jobs:
 
     - uses: docker/setup-buildx-action@v3
 
+    - name: Install dependencies
+      run: |
+        sudo apt-get install zsh libboost-all-dev
+
     - name: Build Docker image
       uses: docker/build-push-action@v6
       with:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -110,19 +110,13 @@ jobs:
 
     - name: Build Docker image
       uses: docker/build-push-action@v6
-      id: build
       with:
         context: .
-
         file: Dockerfile.alpine
-
         platforms: ${{ matrix.platform }}
-
         tags: noseyparker
-
+        load: true
         target: builder
-
-        outputs: type=image,name=noseyparker,push=false
 
     - name: Inspect Docker image
       run: |

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -122,18 +122,18 @@ jobs:
 
         target: builder
 
-        outputs: type=image
+        outputs: type=image,name=noseyparker,push=false
 
     - name: Inspect Docker image
       run: |
-        docker buildx imagetools inspect "noseyparker@${{ steps.build.outputs.digest }}"
+        docker buildx imagetools inspect noseyparker
 
     - name: Test Docker image
-      run: docker run --rm "noseyparker@${{ steps.build.outputs.digest }}" --version
+      run: docker run --rm noseyparker --version
 
     - name: Copy release build from Docker container
       run: |
-        docker run --name np "noseyparker@${{ steps.build.outputs.digest }}"
+        docker run --name np noseyparker
         docker cp np:/release release
         docker rm np
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -118,9 +118,6 @@ jobs:
         load: true
         target: builder
 
-    - name: Test Docker image
-      run: docker run --rm noseyparker --version
-
     - name: Copy release build from Docker container
       run: |
         docker run --name np noseyparker

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -124,14 +124,14 @@ jobs:
 
     - name: Inspect Docker image
       run: |
-        docker buildx imagetools inspect "noseyparker:sha256@${{ steps.build.outputs.digest }}"
+        docker buildx imagetools inspect "noseyparker@${{ steps.build.outputs.digest }}"
 
     - name: Test Docker image
-      run: docker run --rm "noseyparker:sha256@${{ steps.build.outputs.digest }}" --version
+      run: docker run --rm "noseyparker@${{ steps.build.outputs.digest }}" --version
 
     - name: Copy release build from Docker container
       run: |
-        docker cp $(docker run --name np "noseyparker:sha256@${{ steps.build.outputs.digest }}"):/usr/local release
+        docker cp $(docker run --name np "noseyparker@${{ steps.build.outputs.digest }}"):/usr/local release
         docker rm np
 
     - name: Run integration tests on release

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -82,3 +82,77 @@ jobs:
         path: ${{ steps.release-archive.outputs.filename }}
         compression-level: 0
         if-no-files-found: error
+
+
+  # Build the Alpine-based Docker image, then copy it out of there to create a
+  # standalone release from that
+  linux-musl:
+    strategy:
+      matrix:
+        include:
+        - base: alpine
+          platform: linux/amd64
+          platform-pair: linux-amd64
+          runs-on: ubuntu-22.04
+
+        - base: alpine
+          platform: linux/arm64
+          platform-pair: linux-arm64
+          runs-on: ubuntu-22.04-arm64-8-core
+
+    name: Linux (${{ matrix.platform }} musl
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v6
+      id: build
+      with:
+        context: .
+
+        file: Dockerfile.alpine
+
+        platforms: ${{ matrix.platform }}
+
+        tags: noseyparker
+
+        outputs: type=image
+
+    - name: Inspect Docker image
+      run: |
+        docker buildx imagetools inspect "noseyparker:sha256@${{ steps.build.outputs.digest }}"
+
+    - name: Test Docker image
+      run: docker run --rm "noseyparker:sha256@${{ steps.build.outputs.digest }}" --version
+
+    - name: Copy release build from Docker container
+      run: |
+        docker cp $(docker run --rm "noseyparker:sha256@${{ steps.build.outputs.digest }}"):/usr/local release
+
+    - name: Run integration tests on release
+      run: |
+        NP_TEST_PROGRAM="$PWD"/release/bin/noseyparker cargo test --test test_noseyparker
+      env:
+        # We use the GitHub Actions automatic token when running tests, to avoid
+        # spurious failures from rate limiting when testing Nosey Parker's github
+        # enumeration capabilities.
+        NP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create release archive
+      id: release-archive
+      run: |
+        FILENAME="$(./release/bin/noseyparker -V | tr ' ' '-').tar.gz"
+        tar -C release -c -z -f "$FILENAME" .
+        echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+    - name: Upload release files
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.release-archive.outputs.filename }}
+        path: ${{ steps.release-archive.outputs.filename }}
+        compression-level: 0
+        if-no-files-found: error

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -131,7 +131,8 @@ jobs:
 
     - name: Copy release build from Docker container
       run: |
-        docker cp $(docker run --rm "noseyparker:sha256@${{ steps.build.outputs.digest }}"):/usr/local release
+        docker cp $(docker run --name np "noseyparker:sha256@${{ steps.build.outputs.digest }}"):/usr/local release
+        docker rm np
 
     - name: Run integration tests on release
       run: |


### PR DESCRIPTION
The approach for building statically-linked releases is to build the Alpine-based Docker image, then copy the resulting release out of there.

Fixes #177.