### PR TITLE
Fix crash when non-object JSON values are used for enumerator provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Unreleased
 
 ### Breaking Changes
-- The JSON output format from `report` has changed slightly.
+- The JSON output format from `report` has changed slightly ([#235](https://github.com/praetorian-inc/noseyparker/pull/235)).
 
   Now, the JSON representation of provenance entries from extensible enumerators (i.e., `scan --enumerator=FILE`, introduced in v0.20.0) includes an additional `"payload"` field around the actual provenance content.
   For example, an extended provenance entry that previously would look like this:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Breaking Changes
+- The JSON output format from `report` has changed slightly.
+
+  Now, the JSON representation of provenance entries from extensible enumerators (i.e., `scan --enumerator=FILE`, introduced in v0.20.0) includes an additional `"payload"` field around the actual provenance content.
+  For example, an extended provenance entry that previously would look like this:
+
+      {"kind": "extended", "filename": "input.txt"}
+
+  is now represented like this:
+
+      {"kind": "extended", "payload": {"filename": "input.txt"}}
+
+  This fixes a bug in v0.20.0 where provenance entries from an extensible enumerator could _only_ be JSON objects, instead of arbitrary JSON values as claimed by the documentation.
+
+
 ### Additions
 - New rules have been added:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,6 +2914,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "test-case",
  "thiserror",
  "tokio",
  "tracing",
@@ -4346,6 +4347,39 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "test-case-core",
+]
 
 [[package]]
 name = "thiserror"

--- a/crates/noseyparker-cli/tests/generate/snapshots/test_noseyparker__generate__generate_json_schema.snap
+++ b/crates/noseyparker-cli/tests/generate/snapshots/test_noseyparker__generate__generate_json_schema.snap
@@ -313,10 +313,12 @@ expression: stdout
                 "extended"
               ],
               "type": "string"
-            }
+            },
+            "payload": true
           },
           "required": [
-            "kind"
+            "kind",
+            "payload"
           ],
           "type": "object"
         }

--- a/crates/noseyparker-cli/tests/scan/basic/mod.rs
+++ b/crates/noseyparker-cli/tests/scan/basic/mod.rs
@@ -210,6 +210,20 @@ fn scan_enumerator_base64_1() {
 }
 
 #[test]
+fn scan_enumerator_string_provenance() {
+    let scan_env = ScanEnv::new();
+
+    let input = scan_env.input_with_secret();
+    let jsonl_input = &serde_json::json!({
+        "content": input,
+        "provenance": "input.txt",
+    })
+    .to_string();
+    let enumerator_input = scan_env.input_file_with_contents("input.txt", jsonl_input);
+    scan_enumerator_common!(&scan_env, enumerator_input);
+}
+
+#[test]
 fn scan_default_datastore() {
     let scan_env = ScanEnv::new();
     let input = scan_env.input_file("input.txt");

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_base64_1-7.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_base64_1-7.snap
@@ -40,8 +40,10 @@ expression: json_output
         },
         "provenance": [
           {
-            "filename": "input.txt",
-            "kind": "extended"
+            "kind": "extended",
+            "payload": {
+              "filename": "input.txt"
+            }
           }
         ],
         "rule_name": "GitHub Personal Access Token",

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-2.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-2.snap
@@ -1,0 +1,7 @@
+---
+source: crates/noseyparker-cli/tests/scan/basic/mod.rs
+expression: stdout
+---
+ Rule                           Findings   Matches   Accepted   Rejected   Mixed   Unlabeled 
+─────────────────────────────────────────────────────────────────────────────────────────────
+ GitHub Personal Access Token          1         1          0          0       0           1

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-3.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-3.snap
@@ -1,0 +1,5 @@
+---
+source: crates/noseyparker-cli/tests/scan/basic/mod.rs
+expression: stderr
+---
+

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-4.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-4.snap
@@ -1,0 +1,5 @@
+---
+source: crates/noseyparker-cli/tests/scan/basic/mod.rs
+expression: status
+---
+exit status: 0

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-5.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-5.snap
@@ -1,0 +1,16 @@
+---
+source: crates/noseyparker-cli/tests/scan/basic/mod.rs
+expression: stdout
+---
+Finding 1/1
+Rule: GitHub Personal Access Token
+Group: ghp_XIxB7KMNdAr3zqWtQqhE94qglHqOzn1D1stg
+
+    Occurrence 1/1
+    Extended Provenance: "input.txt"
+    Blob:  <BLOB>
+    Lines: 3:12-3:51
+
+        # This is fake configuration data
+        USERNAME=the_dude
+        GITHUB_KEY=ghp_XIxB7KMNdAr3zqWtQqhE94qglHqOzn1D1stg

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-6.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-6.snap
@@ -1,0 +1,5 @@
+---
+source: crates/noseyparker-cli/tests/scan/basic/mod.rs
+expression: stderr
+---
+

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-7.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance-7.snap
@@ -41,9 +41,7 @@ expression: json_output
         "provenance": [
           {
             "kind": "extended",
-            "payload": {
-              "filename": "input.txt"
-            }
+            "payload": "input.txt"
           }
         ],
         "rule_name": "GitHub Personal Access Token",

--- a/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance.snap
+++ b/crates/noseyparker-cli/tests/scan/basic/snapshots/test_noseyparker__scan__basic__scan_enumerator_string_provenance.snap
@@ -1,0 +1,5 @@
+---
+source: crates/noseyparker-cli/tests/scan/basic/mod.rs
+expression: status
+---
+exit status: 0

--- a/crates/noseyparker/Cargo.toml
+++ b/crates/noseyparker/Cargo.toml
@@ -59,3 +59,4 @@ vectorscan-rs = { version = "0.0.4" }
 
 [dev-dependencies]
 pretty_assertions = "1.3"
+test-case = "3"


### PR DESCRIPTION
Fix a bug in v0.20.0 where provenance entries from an extensible enumerator could _only_ be JSON objects, instead of arbitrary JSON values as claimed by the documentation.

This requires changing the JSON-format report schema slightly.