### PR TITLE
feature(rule): Added new rule for detecting sourcegraph access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Note that the use of semantic versioning applies to the command-line interface a
 - New rules:
 
     - `Credentials in Connect-VIServer Invocation` ([#251](https://github.com/praetorian-inc/noseyparker/pull/251))
+    - `Sourcegraph Access Token` ([#252](https://github.com/praetorian-inc/noseyparker/pull/252))
 
 ### Changes
 - The `Credentials in PsExec` rule has been renamed to `Credentials in PsExec Invocation` ([#251](https://github.com/praetorian-inc/noseyparker/pull/251))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It has found secrets in hundreds of offensive security engagements at [Praetoria
 
 **Key features:**
 - **Flexiblity:** It natively scans files, directories, GitHub, and Git history, and has an extensible input enumeration mechanism
-- **Field-tested rules:** It uses regular expressions with [171 patterns](crates/noseyparker/data/default/builtin/rules) chosen for high precision based on feedback from security engineers
+- **Field-tested rules:** It uses regular expressions with [172 patterns](crates/noseyparker/data/default/builtin/rules) chosen for high precision based on feedback from security engineers
 - **Signal-to-noise:** It deduplicates matches that share the same secret, reducing review burden by 10-1000x or more
 - **Speed & scalability:** it can scan at GB/s on a multicore system, and has scanned inputs as large as 20TB during security engagements
 

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,4 +2,4 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-171 rules and 3 rulesets: no issues detected
+172 rules and 3 rulesets: no issues detected

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -3854,6 +3854,31 @@ expression: stdout
       }
     },
     {
+      "id": "np.sourcegraph.1",
+      "structural_id": "37afa71f65cf37c1b3cf1aa4e7aa472ed567c81b",
+      "name": "Sourcegraph Access Token",
+      "syntax": {
+        "name": "Sourcegraph Access Token",
+        "id": "np.sourcegraph.1",
+        "pattern": "\\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})\\b",
+        "description": null,
+        "examples": [
+          "  sourcegraph access token sgp_fd1b4edb60bf82b8_a70aabf5f685734b19792789feeb73c6393cd02e<br/>",
+          "  access token sgp_b70acbf2f685734c19791789fdeb73c6393dd02a",
+          "  access token sgp_local_b70acbf2f685734c19791789fdeb73c6393dd02a",
+          "var applicationId = 'x-sourcegraph-token';\nvar accessToken = 'sgp_fd1b4edb60bf82b8_a70aabf5f685734b19792789feeb73c6393cd02e';\n"
+        ],
+        "negative_examples": [],
+        "references": [
+          "https://sourcegraph.com/docs/api/graphql"
+        ],
+        "categories": [
+          "api",
+          "secret"
+        ]
+      }
+    },
+    {
       "id": "np.square.1",
       "structural_id": "3f8708418bfa64b2123fac51d9e640838af45cbf",
       "name": "Square Access Token",
@@ -4291,7 +4316,7 @@ expression: stdout
     {
       "id": "default",
       "name": "Nosey Parker default rules",
-      "num_rules": 150
+      "num_rules": 151
     },
     {
       "id": "np.assets",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -3855,13 +3855,13 @@ expression: stdout
     },
     {
       "id": "np.sourcegraph.1",
-      "structural_id": "37afa71f65cf37c1b3cf1aa4e7aa472ed567c81b",
+      "structural_id": "fffe23294947c02acf55bf4cf387d9f98ca313d8",
       "name": "Sourcegraph Access Token",
       "syntax": {
         "name": "Sourcegraph Access Token",
         "id": "np.sourcegraph.1",
-        "pattern": "\\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})\\b",
-        "description": null,
+        "pattern": "\\b(sgp_(?:[a-fA-F0-9]{16}_|local_)?[a-fA-F0-9]{40})\\b",
+        "description": "A Sourcegraph Access Token was found. Sourcegraph is a code search and AI platform. Depending on permissions, an attacker may be able to use this token to access proprietary source code, move laterally to code hosting providers such as GitHub or GitLab, or administer the Sourcegraph organization settings.\n",
         "examples": [
           "  sourcegraph access token sgp_fd1b4edb60bf82b8_a70aabf5f685734b19792789feeb73c6393cd02e<br/>",
           "  access token sgp_b70acbf2f685734c19791789fdeb73c6393dd02a",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -157,6 +157,7 @@ expression: stdout
  np.slack.5           Slack App Token                                               api, secret 
  np.slack.6           Slack Legacy Bot Token                                        api, secret 
  np.sonarqube.1       SonarQube Token                                               api, fuzzy, secret 
+ np.sourcegraph.1     Sourcegraph Access Token                                      api, secret 
  np.square.1          Square Access Token                                           api, secret 
  np.square.2          Square OAuth Secret                                           api, secret 
  np.stackhawk.1       StackHawk API Key                                             api, secret 
@@ -178,6 +179,6 @@ expression: stdout
 
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
- default      Nosey Parker default rules             150 
+ default      Nosey Parker default rules             151 
  np.assets    Nosey Parker asset detection rules      15 
  np.hashes    Nosey Parker password hash rules         6

--- a/crates/noseyparker/data/default/builtin/rules/sourcegraph.yml
+++ b/crates/noseyparker/data/default/builtin/rules/sourcegraph.yml
@@ -3,7 +3,12 @@ rules:
 - name: Sourcegraph Access Token
   id: np.sourcegraph.1
 
-  pattern: '\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})\b'
+  pattern: '\b(sgp_(?:[a-fA-F0-9]{16}_|local_)?[a-fA-F0-9]{40})\b'
+
+  description: >
+    A Sourcegraph Access Token was found.
+    Sourcegraph is a code search and AI platform.
+    Depending on permissions, an attacker may be able to use this token to access proprietary source code, move laterally to code hosting providers such as GitHub or GitLab, or administer the Sourcegraph organization settings.
 
   categories:
   - api

--- a/crates/noseyparker/data/default/builtin/rules/sourcegraph.yml
+++ b/crates/noseyparker/data/default/builtin/rules/sourcegraph.yml
@@ -1,0 +1,21 @@
+rules:
+
+- name: Sourcegraph Access Token
+  id: np.sourcegraph.1
+
+  pattern: '\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})\b'
+
+  categories:
+  - api
+  - secret
+
+  references:
+  - https://sourcegraph.com/docs/api/graphql
+
+  examples:
+  - '  sourcegraph access token sgp_fd1b4edb60bf82b8_a70aabf5f685734b19792789feeb73c6393cd02e<br/>'
+  - '  access token sgp_b70acbf2f685734c19791789fdeb73c6393dd02a'
+  - "  access token sgp_local_b70acbf2f685734c19791789fdeb73c6393dd02a"
+  - |
+      var applicationId = 'x-sourcegraph-token';
+      var accessToken = 'sgp_fd1b4edb60bf82b8_a70aabf5f685734b19792789feeb73c6393cd02e';

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -145,6 +145,7 @@ rulesets:
   - np.slack.5        # Slack App Token
   - np.slack.6        # Slack Legacy Bot Token
   - np.sonarqube.1    # SonarQube Token
+  - np.sourcegraph.1  # Sourcegraph Personal Access Token
   - np.square.1       # Square Access Token
   - np.square.2       # Square OAuth Secret
   - np.stackhawk.1    # StackHawk API Key

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -145,7 +145,7 @@ rulesets:
   - np.slack.5        # Slack App Token
   - np.slack.6        # Slack Legacy Bot Token
   - np.sonarqube.1    # SonarQube Token
-  - np.sourcegraph.1  # Sourcegraph Personal Access Token
+  - np.sourcegraph.1  # Sourcegraph Access Token
   - np.square.1       # Square Access Token
   - np.square.2       # Square OAuth Secret
   - np.stackhawk.1    # StackHawk API Key


### PR DESCRIPTION
Added sourcegraph access token rule and tested it locally. Happy to make changes if any.

### Test

- [x] Added test

```bash
running 6 tests
test rules::rules_list_no_builtins ... ok
test rules::rules_list_jsonl ... ok
test help::help_rules ... ok
test rules::rules_list_noargs ... ok
test rules::rules_list_json ... ok
test rules::rules_check_builtins ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 78 filtered out; finished in 2.77s
```