### PR TITLE
Switch from Ubuntu 20.04 to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: ubuntu-20.04.x86_64.stable.release
-          os: ubuntu-20.04
+        - name: ubuntu-22.04.x86_64.stable.release
+          os: ubuntu-22.04
           rust: stable
           profile: release
           features: -F release

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - build: ubuntu-20.04.x86_64
-          os: ubuntu-20.04
+        - build: ubuntu-22.04.x86_64
+          os: ubuntu-22.04
           rust: stable
           install_dependencies: |
             sudo apt-get install zsh libboost-all-dev


### PR DESCRIPTION
GitHub Actions has retired the Ubuntu 20.04 runners.