### PR TITLE
Add updated Azure DevOps PAT format

### DIFF
--- a/crates/noseyparker/data/default/builtin/rules/azure.yml
+++ b/crates/noseyparker/data/default/builtin/rules/azure.yml
@@ -134,3 +134,34 @@ rules:
   - api
   - fuzzy
   - secret
+
+- name: Azure DevOps Personal Access Token 
+  id: np.azure.4
+
+  pattern: '\b([a-zA-Z0-9+/]{75}AZDO[a-zA-Z0-9+/=]{5})\b'
+
+  references:
+  - https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#changes-to-format
+  - https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
+
+  categories:
+  - api
+  - secret
+
+  examples:
+  - '6RtqHqPc66Y6DYbkydbrrFJTYnRoA7r40ts7LWS2SkINSFsRABxhJQQJ99BFACAAAAALGcqjAAASAZDO3eqU'
+  - 'a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2w3X4y5Z6a7B8c9D0e1F2g3H4i5J6k7L8m9AZDOn0p1Q'
+  - 'X9y8Z7a6B5c4D3e2F1g0H9i8J7k6L5m4N3o2P1q0R9s8T7u6V5w4X3y2Z1a0B9c8D7e6F5g4H3i2J1k0AZDOl9M8n'
+  - 'QwErTy123456789AbCdEf0123456789AbCdEf0123456789AbCdEf0123456789AbCdEf012345AZDOabc12'
+
+  negative_examples:
+  - '6RtqHqPc66Y6DYbkydbrrFJTYnRoA7r40ts7LWS2SkINSFsRABxhJQQJ99BFACAAAAALGcqjAAASAZDO3eq'
+  - 'X9y8Z7a6B5c4D3e2F1g0H9i8J7k6L5m4N3o2P1q0R9s8T7u6V5w4X3y2Z1a0B9c8D7e6F5g4H3i2J1k0AZDOl9M8nX'
+  - 'zpczok4kqgnw5prpfy3ehiylbqvgbjfkdiqkejsxqamy7qbkep7q'
+  - 'a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2w3X4y5Z6a7B8c9D0e1F2g3H4i5J6k7L8m9XXXX12345'
+
+  description: >
+    Azure DevOps Personal Access Token in the new 84-character format detected. 
+    These tokens contain 52 characters of randomized data with improved entropy and 
+    include a fixed 'AZDO' signature at positions 76-79, making them more resistant 
+    to brute force attacks and easier to identify.


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#changes-to-format

> As of July 2024, we updated the format of PAT strings to improve secret detection in our [leaked PAT detection tooling](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-pats-with-policies-for-administrators?view=azure-devops#revoke-leaked-pats-automatically-tenant-policy) and [partner offerings](https://learn.microsoft.com/en-us/azure/devops/repos/security/github-advanced-security-secret-scanning?view=azure-devops). This new PAT format includes more identifiable bits to improve the false positive detection rate in these detection tools and mitigate detected leaks faster.

> New tokens are now 84 characters long, with 52 characters being randomized data, which improves overall entropy, making tokens more resistant to brute force attacks.
Tokens issued by our service include a fixed AZDO signature at positions 76-80.
If you're using a PAT issued before that data, regenerate your PAT. If you integrate with PATs and have PAT validation built in, update your validate code to accommodate both new and existing token lengths.

Add new rule to identify updated Azure DevOps PATs

