### PR TITLE
Add rule: Twitch Stream Key

### DIFF
--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,4 +2,4 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-188 rules and 3 rulesets: no issues detected
+189 rules and 3 rulesets: no issues detected

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -4613,6 +4613,35 @@ expression: stdout
       }
     },
     {
+      "id": "np.twitch.1",
+      "structural_id": "29992a4304a9e161038079d7064bbe00e29a3cd5",
+      "name": "Twitch Stream Key",
+      "syntax": {
+        "name": "Twitch Stream Key",
+        "id": "np.twitch.1",
+        "pattern": "(?xi)\n(?:\n  \\b (?:twitch)? (?:[_-]?)? stream (?:[_-]?)? key \\b\n  [^A-Za-z0-9]{0,3}\n)?\n[\"']?\n(\n  live_                                (?# live_ prefix)\n  \\d{8,12}                             (?# 8–12 digit account ID - examples have 9, unsure of variance)\n  _\n  [A-Za-z0-9]{30,36}                   (?# underscore followed by 30-36 chars)\n)\n[\"']?\n",
+        "description": null,
+        "examples": [
+          "STREAM_KEY=live_126031192_RJVJxpxq8Q1X1Qdc9SwwTvpXonANmi",
+          "live_126031192_tiX3sbwIzL9VmkecdxioBMA1LJ9S4m",
+          "live_126031192_IgvUabrXbWSihj2ENnA59G1F8349jn",
+          "live_126031192_m3owJxYRKOf531B9Zc3ZQcLfOLCzKK"
+        ],
+        "negative_examples": [
+          "TWITCH_STREAM_KEY = \"126031192_IgvUabrXbWSihj2ENnA59G1F8\"",
+          "live_126031192_IgvUabrXbWSihj2ENnA59G1F8",
+          "stream_url: \"rtmp://live.twitch.tv/app/STREAM_KEY\""
+        ],
+        "references": [
+          "https://help.twitch.tv/s/article/twitch-stream-key-faq?language=en_US"
+        ],
+        "categories": [
+          "api",
+          "secret"
+        ]
+      }
+    },
+    {
       "id": "np.twitter.1",
       "structural_id": "1e0cb253c7c5f1244b5a37b74b8a6a5199ce4432",
       "name": "Twitter Client ID",
@@ -4739,7 +4768,7 @@ expression: stdout
     {
       "id": "default",
       "name": "Nosey Parker default rules",
-      "num_rules": 167
+      "num_rules": 168
     },
     {
       "id": "np.assets",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -187,6 +187,7 @@ expression: stdout
  np.truenas.1         TrueNAS API Key (WebSocket)                                   api, fuzzy, secret 
  np.truenas.2         TrueNAS API Key (REST API)                                    api, fuzzy, secret 
  np.twilio.1          Twilio API Key                                                api, fuzzy, secret 
+ np.twitch.1          Twitch Stream Key                                             api, secret 
  np.twitter.1         Twitter Client ID                                             api, fuzzy, identifier 
  np.twitter.2         Twitter Secret Key                                            api, fuzzy, secret 
  np.vmware.1          Credentials in Connect-VIServer Invocation                    fuzzy, secret 
@@ -195,6 +196,6 @@ expression: stdout
 
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
- default      Nosey Parker default rules             167 
+ default      Nosey Parker default rules             168 
  np.assets    Nosey Parker asset detection rules      15 
  np.hashes    Nosey Parker password hash rules         6

--- a/crates/noseyparker/data/default/builtin/rules/twitch.yml
+++ b/crates/noseyparker/data/default/builtin/rules/twitch.yml
@@ -1,0 +1,35 @@
+rules:
+
+- name: Twitch Stream Key
+  id: np.twitch.1
+
+  pattern: |
+    (?xi)
+    (?:
+      \b (?:twitch)? (?:[_-]?)? stream (?:[_-]?)? key \b
+      [^A-Za-z0-9]{0,3}
+    )?
+    ["']?
+    (
+      live_                                (?# live_ prefix)
+      \d{8,12}                             (?# 8–12 digit account ID - examples have 9, unsure of variance)
+      _
+      [A-Za-z0-9]{30,36}                   (?# underscore followed by 30-36 chars)
+    )
+    ["']?
+
+  categories: [api, secret]
+
+  references:
+  - https://help.twitch.tv/s/article/twitch-stream-key-faq?language=en_US
+
+  examples:
+  - 'STREAM_KEY=live_126031192_RJVJxpxq8Q1X1Qdc9SwwTvpXonANmi'
+  - 'live_126031192_tiX3sbwIzL9VmkecdxioBMA1LJ9S4m'
+  - 'live_126031192_IgvUabrXbWSihj2ENnA59G1F8349jn'
+  - 'live_126031192_m3owJxYRKOf531B9Zc3ZQcLfOLCzKK'
+
+  negative_examples:
+  - 'TWITCH_STREAM_KEY = "126031192_IgvUabrXbWSihj2ENnA59G1F8"'   # no live_ prefix
+  - 'live_126031192_IgvUabrXbWSihj2ENnA59G1F8'                    # body too short
+  - 'stream_url: "rtmp://live.twitch.tv/app/STREAM_KEY"'          # generic URL with no stream key

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -176,6 +176,7 @@ rulesets:
   - np.truenas.2      # TrueNAS API Key (REST API)
   - np.twilio.1       # Twilio API Key
   - np.twitter.2      # Twitter Secret Key
+  - np.twitch.1       # Twitch Stream Key
   - np.vmware.1       # Credentials in Connect-VIServer Command
   - np.wireguard.1    # WireGuard Private Key
   - np.wireguard.2    # WireGuard Preshared Key


### PR DESCRIPTION
Rule added for Twitch stream keys

Cursory testing/validation was done via [code search](https://github.com/search?q=content%3A%2F%5Cblive_%5B0-9%5D%7B8%2C12%7D_%5BA-Za-z0-9%5D%7B30%2C36%7D%5Cb%2F&type=code)

Examples given are not real/valid, but are in the same format