### PR TITLE
Add new OpenAI API Key

### DIFF
--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_check_builtins-2.snap
@@ -2,4 +2,4 @@
 source: crates/noseyparker-cli/tests/rules/mod.rs
 expression: stdout
 ---
-189 rules and 3 rulesets: no issues detected
+193 rules and 3 rulesets: no issues detected

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -3348,6 +3348,96 @@ expression: stdout
       }
     },
     {
+      "id": "np.openai.2",
+      "structural_id": "6f849ebde80451dd8a36554daed1db1bcd06411e",
+      "name": "OpenAI Project API Key",
+      "syntax": {
+        "name": "OpenAI Project API Key",
+        "id": "np.openai.2",
+        "pattern": "(?x)\n\\b\n(\nsk-proj-                             (?# Project API Key prefix )\n[a-zA-Z0-9_-]{48}\n)\n\\b\n",
+        "description": null,
+        "examples": [
+          "   OPENAI_API_KEY=\"sk-proj-QQmRn0z0jGG5W29rn0CwDVJbRivNE8YpCSBBkEVW20vUCF7w\""
+        ],
+        "negative_examples": [],
+        "references": [
+          "https://platform.openai.com/docs/api-reference/project-api-keys",
+          "https://community.openai.com/t/project-api-key-length-has-it-changed-from-48-to-156/920777"
+        ],
+        "categories": [
+          "api",
+          "secret"
+        ]
+      }
+    },
+    {
+      "id": "np.openai.3",
+      "structural_id": "36e7547ee36ea99acb07380ef83ee61924993e1c",
+      "name": "OpenAI Project API Key v2",
+      "syntax": {
+        "name": "OpenAI Project API Key v2",
+        "id": "np.openai.3",
+        "pattern": "(?x)\n\\b\n(\nsk-proj-                             (?# Project API Key prefix )\n[a-zA-Z0-9_-]{156}\n)\n\\b\n",
+        "description": null,
+        "examples": [
+          "OPENAI_API_KEY=sk-proj-bUWRyHzhUjxyJsw8VzD-boWSOX-lWFpL9ZVVwgzH3SnvblGeiC72duqxiezuLlxfRfgXOZ-swIXPAqHahMfkPZFrWEZ9Ky27WSgiw4ofBv-yKYXEWw7IOORz01ARkASGVE8kFw2kMpVk_Ufn_ogEN2Fyjw9d\nOPENAI_MODEL=gpt-5-nano-2025-08-07\n"
+        ],
+        "negative_examples": [],
+        "references": [
+          "https://platform.openai.com/docs/api-reference/project-api-keys",
+          "https://community.openai.com/t/project-api-key-length-has-it-changed-from-48-to-156/920777"
+        ],
+        "categories": [
+          "api",
+          "secret"
+        ]
+      }
+    },
+    {
+      "id": "np.openai.4",
+      "structural_id": "9f7710643b2b83ec8900206e34ce1766d5153565",
+      "name": "OpenAI Admin API Key",
+      "syntax": {
+        "name": "OpenAI Admin API Key",
+        "id": "np.openai.4",
+        "pattern": "(?x)\n\\b\n(\nsk-admin-                            (?# Admin API Key prefix )\n[a-zA-Z0-9_-]{124}\n)\n\\b\n",
+        "description": null,
+        "examples": [
+          "   OPENAI_ADMIN_API_KEY=\"sk-admin-90E9ZsxRiCay6CSW3Ftmq-n3IJ1gKDC-EtwNOpHf18LAvSae4uyKrygUf87jxzt-tfmcYpjS5X3WbPcQQu39OPh7xBkW4-c9imO9yQVzPnjd4fjpNS_w4nMJeAOx\""
+        ],
+        "negative_examples": [],
+        "references": [
+          "https://platform.openai.com/docs/api-reference/admin-api-keys"
+        ],
+        "categories": [
+          "api",
+          "secret"
+        ]
+      }
+    },
+    {
+      "id": "np.openai.5",
+      "structural_id": "f5205ec41ebfd7c3fa1dea7bf91805bb572e7de9",
+      "name": "OpenAI Project Service Account",
+      "syntax": {
+        "name": "OpenAI Project Service Account",
+        "id": "np.openai.5",
+        "pattern": "(?x)\n\\b\n(\nsk-svcacct-                          (?# Project Service Account prefix )\n[a-zA-Z0-9_-]{156}\n)\n\\b\n",
+        "description": null,
+        "examples": [
+          "OPENAI_API_KEY = \"sk-svcacct-cD3v20igDxpt-JpaQxnbqiex3ko2WcW_IQNyhRAEgzCqMlgYPRN2pAqZ8-kyFqGAxJkdUtaG30_6aYZuU0nNRJq9l4-h3wJ9VkZtz3ybX1fT8GchB6D7M00BBXajfQNOi_-rSCYvGJ-NiFyEPzcPSAj20sIF\"\nOPENAI_WS_URI = \"wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17\"\n"
+        ],
+        "negative_examples": [],
+        "references": [
+          "https://platform.openai.com/docs/api-reference/project-service-accounts"
+        ],
+        "categories": [
+          "api",
+          "secret"
+        ]
+      }
+    },
+    {
       "id": "np.particleio.1",
       "structural_id": "8ab26f61a067886b886641bd883f453b2355f85d",
       "name": "particle.io Access Token",
@@ -4768,7 +4858,7 @@ expression: stdout
     {
       "id": "default",
       "name": "Nosey Parker default rules",
-      "num_rules": 168
+      "num_rules": 172
     },
     {
       "id": "np.assets",

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_json-2.snap
@@ -3355,7 +3355,7 @@ expression: stdout
         "name": "OpenAI Project API Key",
         "id": "np.openai.2",
         "pattern": "(?x)\n\\b\n(\nsk-proj-                             (?# Project API Key prefix )\n[a-zA-Z0-9_-]{48}\n)\n\\b\n",
-        "description": null,
+        "description": "OpenAI Project API Key (legacy 48-character format, deprecated August 2024).\n",
         "examples": [
           "   OPENAI_API_KEY=\"sk-proj-QQmRn0z0jGG5W29rn0CwDVJbRivNE8YpCSBBkEVW20vUCF7w\""
         ],
@@ -3378,7 +3378,7 @@ expression: stdout
         "name": "OpenAI Project API Key v2",
         "id": "np.openai.3",
         "pattern": "(?x)\n\\b\n(\nsk-proj-                             (?# Project API Key prefix )\n[a-zA-Z0-9_-]{156}\n)\n\\b\n",
-        "description": null,
+        "description": "OpenAI Project API Key (current 156-character format, introduced August 2024).\n",
         "examples": [
           "OPENAI_API_KEY=sk-proj-bUWRyHzhUjxyJsw8VzD-boWSOX-lWFpL9ZVVwgzH3SnvblGeiC72duqxiezuLlxfRfgXOZ-swIXPAqHahMfkPZFrWEZ9Ky27WSgiw4ofBv-yKYXEWw7IOORz01ARkASGVE8kFw2kMpVk_Ufn_ogEN2Fyjw9d\nOPENAI_MODEL=gpt-5-nano-2025-08-07\n"
         ],
@@ -3401,7 +3401,7 @@ expression: stdout
         "name": "OpenAI Admin API Key",
         "id": "np.openai.4",
         "pattern": "(?x)\n\\b\n(\nsk-admin-                            (?# Admin API Key prefix )\n[a-zA-Z0-9_-]{124}\n)\n\\b\n",
-        "description": null,
+        "description": "OpenAI Admin API Key for organization-wide administrative operations.\n",
         "examples": [
           "   OPENAI_ADMIN_API_KEY=\"sk-admin-90E9ZsxRiCay6CSW3Ftmq-n3IJ1gKDC-EtwNOpHf18LAvSae4uyKrygUf87jxzt-tfmcYpjS5X3WbPcQQu39OPh7xBkW4-c9imO9yQVzPnjd4fjpNS_w4nMJeAOx\""
         ],
@@ -3423,7 +3423,7 @@ expression: stdout
         "name": "OpenAI Project Service Account",
         "id": "np.openai.5",
         "pattern": "(?x)\n\\b\n(\nsk-svcacct-                          (?# Project Service Account prefix )\n[a-zA-Z0-9_-]{156}\n)\n\\b\n",
-        "description": null,
+        "description": "OpenAI Project Service Account API Key for automated systems and CI/CD pipelines.\n",
         "examples": [
           "OPENAI_API_KEY = \"sk-svcacct-cD3v20igDxpt-JpaQxnbqiex3ko2WcW_IQNyhRAEgzCqMlgYPRN2pAqZ8-kyFqGAxJkdUtaG30_6aYZuU0nNRJq9l4-h3wJ9VkZtz3ybX1fT8GchB6D7M00BBXajfQNOi_-rSCYvGJ-NiFyEPzcPSAj20sIF\"\nOPENAI_WS_URI = \"wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17\"\n"
         ],

--- a/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
+++ b/crates/noseyparker-cli/tests/rules/snapshots/test_noseyparker__rules__rules_list_noargs-2.snap
@@ -137,6 +137,10 @@ expression: stdout
  np.odbc.1            Credentials in ODBC Connection String                         fuzzy, secret 
  np.okta.1            Okta API Token                                                api, secret 
  np.openai.1          OpenAI API Key                                                api, secret 
+ np.openai.2          OpenAI Project API Key                                        api, secret 
+ np.openai.3          OpenAI Project API Key v2                                     api, secret 
+ np.openai.4          OpenAI Admin API Key                                          api, secret 
+ np.openai.5          OpenAI Project Service Account                                api, secret 
  np.particleio.1      particle.io Access Token                                      api, secret 
  np.particleio.2      particle.io Access Token                                      api, secret 
  np.pem.1             PEM-Encoded Private Key                                       secret 
@@ -196,6 +200,6 @@ expression: stdout
 
  Ruleset ID   Ruleset Name                         Rules 
 ─────────────────────────────────────────────────────────
- default      Nosey Parker default rules             168 
+ default      Nosey Parker default rules             172 
  np.assets    Nosey Parker asset detection rules      15 
  np.hashes    Nosey Parker password hash rules         6

--- a/crates/noseyparker/data/default/builtin/rules/openai.yml
+++ b/crates/noseyparker/data/default/builtin/rules/openai.yml
@@ -18,3 +18,93 @@ rules:
   references:
   - https://platform.openai.com/docs/api-reference
   - https://platform.openai.com/docs/api-reference/authentication
+
+
+- name: OpenAI Project API Key
+  id: np.openai.2
+
+  pattern: |
+    (?x)
+    \b
+    (
+    sk-proj-                             (?# Project API Key prefix )
+    [a-zA-Z0-9_-]{48}
+    )
+    \b
+
+  categories: [api, secret]
+
+  references:
+  - https://platform.openai.com/docs/api-reference/project-api-keys
+  - https://community.openai.com/t/project-api-key-length-has-it-changed-from-48-to-156/920777
+
+  examples:
+  - '   OPENAI_API_KEY="sk-proj-QQmRn0z0jGG5W29rn0CwDVJbRivNE8YpCSBBkEVW20vUCF7w"'
+
+
+- name: OpenAI Project API Key v2
+  id: np.openai.3
+
+  pattern: |
+    (?x)
+    \b
+    (
+    sk-proj-                             (?# Project API Key prefix )
+    [a-zA-Z0-9_-]{156}
+    )
+    \b
+
+  categories: [api, secret]
+
+  references:
+  - https://platform.openai.com/docs/api-reference/project-api-keys
+  - https://community.openai.com/t/project-api-key-length-has-it-changed-from-48-to-156/920777
+
+  examples:
+  - |
+      OPENAI_API_KEY=sk-proj-bUWRyHzhUjxyJsw8VzD-boWSOX-lWFpL9ZVVwgzH3SnvblGeiC72duqxiezuLlxfRfgXOZ-swIXPAqHahMfkPZFrWEZ9Ky27WSgiw4ofBv-yKYXEWw7IOORz01ARkASGVE8kFw2kMpVk_Ufn_ogEN2Fyjw9d
+      OPENAI_MODEL=gpt-5-nano-2025-08-07
+
+
+- name: OpenAI Admin API Key
+  id: np.openai.4
+
+  pattern: |
+    (?x)
+    \b
+    (
+    sk-admin-                            (?# Admin API Key prefix )
+    [a-zA-Z0-9_-]{124}
+    )
+    \b
+
+  categories: [api, secret]
+
+  references:
+  - https://platform.openai.com/docs/api-reference/admin-api-keys
+
+  examples:
+  - '   OPENAI_ADMIN_API_KEY="sk-admin-90E9ZsxRiCay6CSW3Ftmq-n3IJ1gKDC-EtwNOpHf18LAvSae4uyKrygUf87jxzt-tfmcYpjS5X3WbPcQQu39OPh7xBkW4-c9imO9yQVzPnjd4fjpNS_w4nMJeAOx"'
+
+
+- name: OpenAI Project Service Account
+  id: np.openai.5
+
+  pattern: |
+    (?x)
+    \b
+    (
+    sk-svcacct-                          (?# Project Service Account prefix )
+    [a-zA-Z0-9_-]{156}
+    )
+    \b
+
+  categories: [api, secret]
+
+  references:
+  - https://platform.openai.com/docs/api-reference/project-service-accounts
+
+  examples:
+  - |
+    OPENAI_API_KEY = "sk-svcacct-cD3v20igDxpt-JpaQxnbqiex3ko2WcW_IQNyhRAEgzCqMlgYPRN2pAqZ8-kyFqGAxJkdUtaG30_6aYZuU0nNRJq9l4-h3wJ9VkZtz3ybX1fT8GchB6D7M00BBXajfQNOi_-rSCYvGJ-NiFyEPzcPSAj20sIF"
+    OPENAI_WS_URI = "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17"

--- a/crates/noseyparker/data/default/builtin/rules/openai.yml
+++ b/crates/noseyparker/data/default/builtin/rules/openai.yml
@@ -41,6 +41,9 @@ rules:
   examples:
   - '   OPENAI_API_KEY="sk-proj-QQmRn0z0jGG5W29rn0CwDVJbRivNE8YpCSBBkEVW20vUCF7w"'
 
+  description: >
+    OpenAI Project API Key (legacy 48-character format, deprecated August 2024).
+
 
 - name: OpenAI Project API Key v2
   id: np.openai.3
@@ -65,6 +68,9 @@ rules:
       OPENAI_API_KEY=sk-proj-bUWRyHzhUjxyJsw8VzD-boWSOX-lWFpL9ZVVwgzH3SnvblGeiC72duqxiezuLlxfRfgXOZ-swIXPAqHahMfkPZFrWEZ9Ky27WSgiw4ofBv-yKYXEWw7IOORz01ARkASGVE8kFw2kMpVk_Ufn_ogEN2Fyjw9d
       OPENAI_MODEL=gpt-5-nano-2025-08-07
 
+  description: >
+    OpenAI Project API Key (current 156-character format, introduced August 2024).
+
 
 - name: OpenAI Admin API Key
   id: np.openai.4
@@ -85,6 +91,9 @@ rules:
 
   examples:
   - '   OPENAI_ADMIN_API_KEY="sk-admin-90E9ZsxRiCay6CSW3Ftmq-n3IJ1gKDC-EtwNOpHf18LAvSae4uyKrygUf87jxzt-tfmcYpjS5X3WbPcQQu39OPh7xBkW4-c9imO9yQVzPnjd4fjpNS_w4nMJeAOx"'
+
+  description: >
+    OpenAI Admin API Key for organization-wide administrative operations.
 
 
 - name: OpenAI Project Service Account
@@ -108,3 +117,6 @@ rules:
   - |
     OPENAI_API_KEY = "sk-svcacct-cD3v20igDxpt-JpaQxnbqiex3ko2WcW_IQNyhRAEgzCqMlgYPRN2pAqZ8-kyFqGAxJkdUtaG30_6aYZuU0nNRJq9l4-h3wJ9VkZtz3ybX1fT8GchB6D7M00BBXajfQNOi_-rSCYvGJ-NiFyEPzcPSAj20sIF"
     OPENAI_WS_URI = "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17"
+
+  description: >
+    OpenAI Project Service Account API Key for automated systems and CI/CD pipelines.

--- a/crates/noseyparker/data/default/builtin/rulesets/default.yml
+++ b/crates/noseyparker/data/default/builtin/rulesets/default.yml
@@ -134,6 +134,10 @@ rulesets:
   - np.odbc.1         # Credentials in ODBC Connection String
   - np.okta.1         # Okta API Token
   - np.openai.1       # OpenAI API Key
+  - np.openai.2       # OpenAI Project API Key
+  - np.openai.3       # OpenAI Project API Key v2
+  - np.openai.4       # OpenAI Admin API Key
+  - np.openai.5       # OpenAI Project Service Account
   - np.particleio.1   # particle.io Access Token
   - np.particleio.2   # particle.io Access Token
   - np.pem.1          # PEM-Encoded Private Key


### PR DESCRIPTION
Add 4 new OpenAI rules:
- `OpenAI Project API Key`
- `OpenAI Project API Key v2`
- `OpenAI Admin API Key`
- `OpenAI Project Service Account`

Examples given are not  valid.